### PR TITLE
[DABOM-371] 브로드캐스트 Kafka 그룹명 다중화 구현

### DIFF
--- a/src/main/java/com/project/domain/usagerecord/infra/messaging/UsageRecordKafkaConsumer.java
+++ b/src/main/java/com/project/domain/usagerecord/infra/messaging/UsageRecordKafkaConsumer.java
@@ -24,7 +24,9 @@ public class UsageRecordKafkaConsumer {
     private final ObjectMapper objectMapper;
     private final SsePublisher ssePublisher;
 
-    @KafkaListener(topics = "usage-realtime", containerFactory = "broadcastKafkaListenerContainerFactory")
+    @KafkaListener(
+            topics = "usage-realtime",
+            containerFactory = "broadcastKafkaListenerContainerFactory")
     public void consume(ConsumerRecord<String, String> record) {
         try {
             EventEnvelope<UsageRealtimePayload> envelope =

--- a/src/main/java/com/project/domain/usagerecord/infra/messaging/UsageRecordKafkaConsumer.java
+++ b/src/main/java/com/project/domain/usagerecord/infra/messaging/UsageRecordKafkaConsumer.java
@@ -21,11 +21,13 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class UsageRecordKafkaConsumer {
 
+    private static final String TOPIC_USAGE_REALTIME = "usage-realtime";
+
     private final ObjectMapper objectMapper;
     private final SsePublisher ssePublisher;
 
     @KafkaListener(
-            topics = "usage-realtime",
+            topics = TOPIC_USAGE_REALTIME,
             containerFactory = "broadcastKafkaListenerContainerFactory")
     public void consume(ConsumerRecord<String, String> record) {
         try {

--- a/src/main/java/com/project/domain/usagerecord/infra/messaging/UsageRecordKafkaConsumer.java
+++ b/src/main/java/com/project/domain/usagerecord/infra/messaging/UsageRecordKafkaConsumer.java
@@ -10,6 +10,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.domain.usagerecord.infra.sse.SsePublisher;
+import com.project.global.config.KafkaConfig;
 import com.project.global.event.dto.EventEnvelope;
 import com.project.global.event.dto.usage.UsageRealtimePayload;
 
@@ -28,7 +29,7 @@ public class UsageRecordKafkaConsumer {
 
     @KafkaListener(
             topics = TOPIC_USAGE_REALTIME,
-            containerFactory = "broadcastKafkaListenerContainerFactory")
+            containerFactory = KafkaConfig.BROADCAST_KAFKA_LISTENER_CONTAINER_FACTORY)
     public void consume(ConsumerRecord<String, String> record) {
         try {
             EventEnvelope<UsageRealtimePayload> envelope =

--- a/src/main/java/com/project/domain/usagerecord/infra/messaging/UsageRecordKafkaConsumer.java
+++ b/src/main/java/com/project/domain/usagerecord/infra/messaging/UsageRecordKafkaConsumer.java
@@ -24,7 +24,7 @@ public class UsageRecordKafkaConsumer {
     private final ObjectMapper objectMapper;
     private final SsePublisher ssePublisher;
 
-    @KafkaListener(topics = "usage-realtime", groupId = "usage-service")
+    @KafkaListener(topics = "usage-realtime", containerFactory = "broadcastKafkaListenerContainerFactory")
     public void consume(ConsumerRecord<String, String> record) {
         try {
             EventEnvelope<UsageRealtimePayload> envelope =

--- a/src/main/java/com/project/global/config/KafkaConfig.java
+++ b/src/main/java/com/project/global/config/KafkaConfig.java
@@ -19,7 +19,6 @@ import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
 import org.springframework.kafka.support.serializer.ErrorHandlingDeserializer;
-import org.springframework.kafka.support.serializer.JsonDeserializer;
 import org.springframework.kafka.support.serializer.JsonSerializer;
 
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/project/global/config/KafkaConfig.java
+++ b/src/main/java/com/project/global/config/KafkaConfig.java
@@ -80,7 +80,6 @@ public class KafkaConfig {
         config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
         config.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, StringDeserializer.class);
-        config.put(JsonDeserializer.TRUSTED_PACKAGES, "com.project.*");
         return config;
     }
 

--- a/src/main/java/com/project/global/config/KafkaConfig.java
+++ b/src/main/java/com/project/global/config/KafkaConfig.java
@@ -34,8 +34,10 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class KafkaConfig {
 
+    public static final String BROADCAST_KAFKA_LISTENER_CONTAINER_FACTORY =
+            "broadcastKafkaListenerContainerFactory";
+
     private static final int GROUP_ID_SUFFIX_LENGTH = 8;
-    private static final String HOSTNAME_ENV_KEY = "HOSTNAME";
 
     @Value("${spring.kafka.bootstrap-servers:localhost:9092}")
     private String bootstrapServers;
@@ -103,24 +105,19 @@ public class KafkaConfig {
     // ========================================================================
     // 4. Broadcast Consumer 설정 (인스턴스마다 고유 group ID → 브로드캐스팅)
     // ========================================================================
-    @Bean("broadcastKafkaListenerContainerFactory")
+    @Bean(BROADCAST_KAFKA_LISTENER_CONTAINER_FACTORY)
     public ConcurrentKafkaListenerContainerFactory<String, Object>
             broadcastKafkaListenerContainerFactory() {
         Map<String, Object> config = consumerBaseConfig();
         config.put(
-                ConsumerConfig.GROUP_ID_CONFIG, broadcastGroupIdPrefix + "-" + resolveInstanceId());
+                ConsumerConfig.GROUP_ID_CONFIG,
+                broadcastGroupIdPrefix
+                        + "-"
+                        + UUID.randomUUID().toString().substring(0, GROUP_ID_SUFFIX_LENGTH));
 
         ConcurrentKafkaListenerContainerFactory<String, Object> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(new DefaultKafkaConsumerFactory<>(config));
         return factory;
-    }
-
-    private String resolveInstanceId() {
-        String hostname = System.getenv(HOSTNAME_ENV_KEY);
-        if (hostname != null && !hostname.isBlank()) {
-            return hostname;
-        }
-        return UUID.randomUUID().toString().substring(0, GROUP_ID_SUFFIX_LENGTH);
     }
 }

--- a/src/main/java/com/project/global/config/KafkaConfig.java
+++ b/src/main/java/com/project/global/config/KafkaConfig.java
@@ -34,6 +34,8 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class KafkaConfig {
 
+    private static final int GROUP_ID_SUFFIX_LENGTH = 8;
+
     @Value("${spring.kafka.bootstrap-servers:localhost:9092}")
     private String bootstrapServers;
 
@@ -78,7 +80,7 @@ public class KafkaConfig {
         config.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, StringDeserializer.class);
 
         // Trusted Packages 설정: 모든 패키지의 객체 허용 (보안상 필요시 패키지명 지정)
-        config.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        config.put(JsonDeserializer.TRUSTED_PACKAGES, "com.project.*");
 
         return new DefaultKafkaConsumerFactory<>(config);
     }
@@ -97,8 +99,7 @@ public class KafkaConfig {
     @Bean("broadcastKafkaListenerContainerFactory")
     public ConcurrentKafkaListenerContainerFactory<String, Object>
             broadcastKafkaListenerContainerFactory() {
-        String uniqueGroupId =
-                broadcastGroupIdPrefix + "-" + UUID.randomUUID().toString().substring(0, 8);
+        String uniqueGroupId = broadcastGroupIdPrefix + "-" + resolveInstanceId();
 
         Map<String, Object> config = new HashMap<>();
         config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
@@ -106,11 +107,19 @@ public class KafkaConfig {
         config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
         config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
         config.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, StringDeserializer.class);
-        config.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        config.put(JsonDeserializer.TRUSTED_PACKAGES, "com.project.*");
 
         ConcurrentKafkaListenerContainerFactory<String, Object> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(new DefaultKafkaConsumerFactory<>(config));
         return factory;
+    }
+
+    private String resolveInstanceId() {
+        String hostname = System.getenv("HOSTNAME");
+        if (hostname != null && !hostname.isBlank()) {
+            return hostname;
+        }
+        return UUID.randomUUID().toString().substring(0, GROUP_ID_SUFFIX_LENGTH);
     }
 }

--- a/src/main/java/com/project/global/config/KafkaConfig.java
+++ b/src/main/java/com/project/global/config/KafkaConfig.java
@@ -66,22 +66,25 @@ public class KafkaConfig {
     }
 
     // ========================================================================
-    // 2. Consumer 설정
+    // 2. Consumer 공통 설정
+    // ========================================================================
+    private Map<String, Object> consumerBaseConfig() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        config.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, StringDeserializer.class);
+        config.put(JsonDeserializer.TRUSTED_PACKAGES, "com.project.*");
+        return config;
+    }
+
+    // ========================================================================
+    // 3. 기본 Consumer 설정 (공유 group ID → 로드밸런싱)
     // ========================================================================
     @Bean
     public ConsumerFactory<String, Object> consumerFactory() {
-        Map<String, Object> config = new HashMap<>();
-        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        config.put(ConsumerConfig.GROUP_ID_CONFIG, "example-group"); // 기본 그룹 ID 지정
-        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-
-        // 에러 처리
-        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
-        config.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, StringDeserializer.class);
-
-        // Trusted Packages 설정: 모든 패키지의 객체 허용 (보안상 필요시 패키지명 지정)
-        config.put(JsonDeserializer.TRUSTED_PACKAGES, "com.project.*");
-
+        Map<String, Object> config = consumerBaseConfig();
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, "example-group");
         return new DefaultKafkaConsumerFactory<>(config);
     }
 
@@ -94,20 +97,14 @@ public class KafkaConfig {
     }
 
     // ========================================================================
-    // 3. Broadcast Consumer 설정 (인스턴스마다 고유 group ID → 브로드캐스팅)
+    // 4. Broadcast Consumer 설정 (인스턴스마다 고유 group ID → 브로드캐스팅)
     // ========================================================================
     @Bean("broadcastKafkaListenerContainerFactory")
     public ConcurrentKafkaListenerContainerFactory<String, Object>
             broadcastKafkaListenerContainerFactory() {
-        String uniqueGroupId = broadcastGroupIdPrefix + "-" + resolveInstanceId();
-
-        Map<String, Object> config = new HashMap<>();
-        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
-        config.put(ConsumerConfig.GROUP_ID_CONFIG, uniqueGroupId);
-        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
-        config.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, StringDeserializer.class);
-        config.put(JsonDeserializer.TRUSTED_PACKAGES, "com.project.*");
+        Map<String, Object> config = consumerBaseConfig();
+        config.put(
+                ConsumerConfig.GROUP_ID_CONFIG, broadcastGroupIdPrefix + "-" + resolveInstanceId());
 
         ConcurrentKafkaListenerContainerFactory<String, Object> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();

--- a/src/main/java/com/project/global/config/KafkaConfig.java
+++ b/src/main/java/com/project/global/config/KafkaConfig.java
@@ -35,9 +35,13 @@ import lombok.RequiredArgsConstructor;
 public class KafkaConfig {
 
     private static final int GROUP_ID_SUFFIX_LENGTH = 8;
+    private static final String HOSTNAME_ENV_KEY = "HOSTNAME";
 
     @Value("${spring.kafka.bootstrap-servers:localhost:9092}")
     private String bootstrapServers;
+
+    @Value("${spring.kafka.consumer.group-id:dabom-api-notification}")
+    private String defaultGroupId;
 
     @Value("${spring.kafka.broadcast.group-id-prefix:usage-realtime}")
     private String broadcastGroupIdPrefix;
@@ -84,7 +88,7 @@ public class KafkaConfig {
     @Bean
     public ConsumerFactory<String, Object> consumerFactory() {
         Map<String, Object> config = consumerBaseConfig();
-        config.put(ConsumerConfig.GROUP_ID_CONFIG, "example-group");
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, defaultGroupId);
         return new DefaultKafkaConsumerFactory<>(config);
     }
 
@@ -113,7 +117,7 @@ public class KafkaConfig {
     }
 
     private String resolveInstanceId() {
-        String hostname = System.getenv("HOSTNAME");
+        String hostname = System.getenv(HOSTNAME_ENV_KEY);
         if (hostname != null && !hostname.isBlank()) {
             return hostname;
         }

--- a/src/main/java/com/project/global/config/KafkaConfig.java
+++ b/src/main/java/com/project/global/config/KafkaConfig.java
@@ -42,10 +42,10 @@ public class KafkaConfig {
     @Value("${spring.kafka.bootstrap-servers:localhost:9092}")
     private String bootstrapServers;
 
-    @Value("${spring.kafka.consumer.group-id:dabom-api-notification}")
+    @Value("${spring.kafka.consumer.group-id}")
     private String defaultGroupId;
 
-    @Value("${spring.kafka.broadcast.group-id-prefix:usage-realtime}")
+    @Value("${spring.kafka.broadcast.group-id-prefix}")
     private String broadcastGroupIdPrefix;
 
     // ========================================================================

--- a/src/main/java/com/project/global/config/KafkaConfig.java
+++ b/src/main/java/com/project/global/config/KafkaConfig.java
@@ -2,6 +2,7 @@ package com.project.global.config;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -35,6 +36,9 @@ public class KafkaConfig {
 
     @Value("${spring.kafka.bootstrap-servers:localhost:9092}")
     private String bootstrapServers;
+
+    @Value("${spring.kafka.broadcast.group-id-prefix:usage-realtime}")
+    private String broadcastGroupIdPrefix;
 
     // ========================================================================
     // 1. Producer 설정
@@ -84,6 +88,30 @@ public class KafkaConfig {
         ConcurrentKafkaListenerContainerFactory<String, Object> factory =
                 new ConcurrentKafkaListenerContainerFactory<>();
         factory.setConsumerFactory(consumerFactory());
+        return factory;
+    }
+
+    // ========================================================================
+    // 3. Broadcast Consumer 설정 (인스턴스마다 고유 group ID → 브로드캐스팅)
+    // ========================================================================
+    @Bean("broadcastKafkaListenerContainerFactory")
+    public ConcurrentKafkaListenerContainerFactory<String, Object>
+            broadcastKafkaListenerContainerFactory() {
+        String uniqueGroupId =
+                broadcastGroupIdPrefix + "-" + UUID.randomUUID().toString().substring(0, 8);
+
+        Map<String, Object> config = new HashMap<>();
+        config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        config.put(ConsumerConfig.GROUP_ID_CONFIG, uniqueGroupId);
+        config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        config.put(
+                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        config.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, StringDeserializer.class);
+        config.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory =
+                new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(new DefaultKafkaConsumerFactory<>(config));
         return factory;
     }
 }

--- a/src/main/java/com/project/global/config/KafkaConfig.java
+++ b/src/main/java/com/project/global/config/KafkaConfig.java
@@ -104,8 +104,7 @@ public class KafkaConfig {
         config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         config.put(ConsumerConfig.GROUP_ID_CONFIG, uniqueGroupId);
         config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
-        config.put(
-                ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
+        config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
         config.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, StringDeserializer.class);
         config.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -38,8 +38,10 @@ spring:
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
     consumer:
-      group-id: ${KAFKA_CONSUMER_GROUP_ID:dabom-notification-dev}
+      group-id: ${KAFKA_CONSUMER_GROUP_ID:dabom-api-notification}
       auto-offset-reset: ${KAFKA_AUTO_OFFSET_RESET:earliest}
+    broadcast:
+      group-id-prefix: ${KAFKA_BROADCAST_GROUP_PREFIX:usage-realtime}
     producer:
       key-serializer: org.apache.kafka.common.serialization.StringSerializer
       value-serializer: org.springframework.kafka.support.serializer.JsonSerializer


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

- closed: #12
- jira: DABOM-371

---

## 🎯 목적

Auto Scaling 환경에서 `usage-realtime` 토픽의 메시지를 모든 인스턴스가 수신(브로드캐스팅)할 수 있도록 Kafka consumer group을 다중화한다.

각 인스턴스가 SSE로 연결된 클라이언트에게 실시간 사용량을 전달하는 구조이므로, 하나의 인스턴스만 메시지를 소비하면 다른 인스턴스에 연결된 클라이언트는 업데이트를 받지 못하는 문제가 있다.

## 📝 변경 사항

**핵심 기능**
- `KafkaConfig`에 `broadcastKafkaListenerContainerFactory` bean 추가 (인스턴스마다 UUID 기반 고유 consumer group ID 생성)
- `UsageRecordKafkaConsumer`의 `@KafkaListener`에 `broadcastKafkaListenerContainerFactory` 적용, 기존 고정 `groupId` 제거
- `application.yml`에 `spring.kafka.broadcast.group-id-prefix` 프로퍼티 추가 (환경변수 `KAFKA_BROADCAST_GROUP_PREFIX`로 오버라이드 가능)

**리팩토링**
- Consumer 공통 설정을 `consumerBaseConfig()` 메서드로 추출하여 중복 제거
- 하드코딩된 기본 group ID(`"example-group"`) 제거 → `@Value`로 `application.yml`에서 주입
- 기본 consumer group ID를 `dabom-notification-dev` → `dabom-api-notification`으로 변경
- 사용하지 않는 `JsonDeserializer` 관련 설정 및 import 제거 (String 역직렬화만 사용하므로 불필요)
- 빈 이름 상수화 (`BROADCAST_KAFKA_LISTENER_CONTAINER_FACTORY`)
- 토픽 이름 상수화 (`TOPIC_USAGE_REALTIME`)
- 매직 넘버 상수 추출 (`GROUP_ID_SUFFIX_LENGTH`)

## 📂 변경 범위

| 도메인 | controller | service | repository | entity | infra | global |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
| usagerecord |            |         |            |        | [x]   | [x]   |

---

## 🖥️ 주요 코드 설명

```java
// KafkaConfig.java - Consumer 공통 설정 추출
private Map<String, Object> consumerBaseConfig() {
    Map<String, Object> config = new HashMap<>();
    config.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
    config.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
    config.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, ErrorHandlingDeserializer.class);
    config.put(ErrorHandlingDeserializer.VALUE_DESERIALIZER_CLASS, StringDeserializer.class);
    return config;
}

// KafkaConfig.java - 브로드캐스트용 ContainerFactory (UUID로 고유 group ID 생성)
@Bean(BROADCAST_KAFKA_LISTENER_CONTAINER_FACTORY)
public ConcurrentKafkaListenerContainerFactory<String, Object>
        broadcastKafkaListenerContainerFactory() {
    Map<String, Object> config = consumerBaseConfig();
    config.put(ConsumerConfig.GROUP_ID_CONFIG,
            broadcastGroupIdPrefix + "-"
                    + UUID.randomUUID().toString().substring(0, GROUP_ID_SUFFIX_LENGTH));
    // ...
}

// UsageRecordKafkaConsumer.java - 브로드캐스트 팩토리 적용
@KafkaListener(
        topics = TOPIC_USAGE_REALTIME,
        containerFactory = KafkaConfig.BROADCAST_KAFKA_LISTENER_CONTAINER_FACTORY)
public void consume(ConsumerRecord<String, String> record) { ... }
```

같은 group ID를 공유하면 Kafka가 파티션을 분배하여 하나의 인스턴스만 메시지를 소비한다. 인스턴스마다 고유한 group ID를 부여하면 모든 인스턴스가 동일한 메시지를 수신하게 된다. `notification` 토픽은 기존 공유 group ID(`kafkaListenerContainerFactory`)를 사용하여 로드밸런싱을 유지한다.

## 💬 리뷰어에게

- `usage-realtime`만 브로드캐스팅 대상이며, `notification` 토픽은 기존 방식(공유 group ID) 그대로입니다.
- 인스턴스 식별은 UUID 8자리로 단순화했습니다. (초기 HOSTNAME 기반 방식에서 리팩토링)
- Consumer 공통 설정을 `consumerBaseConfig()`로 추출하여 기본/브로드캐스트 Factory 간 중복을 제거했습니다.
- `JsonDeserializer`는 실제로 String 역직렬화만 사용하므로 관련 설정과 import를 제거했습니다.

---

## 📋 체크리스트

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [ ] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

- 변경 파일 3개, 총 +51줄 / -12줄
- 로컬에서 인스턴스 2개 기동 후 `kafka-consumer-groups.sh --list`로 서로 다른 group ID가 생성되는지 검증 가능
