### PR TITLE
[DABOM-397] 알림 Kafka Consumer 추가 및 연결

### DIFF
--- a/src/main/java/com/project/domain/notification/entity/NotificationLog.java
+++ b/src/main/java/com/project/domain/notification/entity/NotificationLog.java
@@ -1,0 +1,69 @@
+package com.project.domain.notification.entity;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+
+import com.project.global.util.BaseEntity;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "notification_log")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class NotificationLog extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "customer_id", nullable = false)
+    private Long customerId;
+
+    @Column(name = "family_id", nullable = false)
+    private Long familyId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private NotificationType type;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String message;
+
+    @Column(columnDefinition = "json")
+    private String payload;
+
+    @Column(name = "is_read", nullable = false)
+    private boolean isRead;
+
+    @Column(name = "sent_at")
+    private LocalDateTime sentAt;
+
+    @Builder
+    public NotificationLog(
+            Long customerId,
+            Long familyId,
+            NotificationType type,
+            String message,
+            String payload,
+            LocalDateTime sentAt) {
+        this.customerId = customerId;
+        this.familyId = familyId;
+        this.type = type;
+        this.message = message;
+        this.payload = payload;
+        this.isRead = false;
+        this.sentAt = sentAt;
+    }
+}

--- a/src/main/java/com/project/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/project/domain/notification/entity/NotificationType.java
@@ -1,0 +1,16 @@
+package com.project.domain.notification.entity;
+
+public enum NotificationType {
+    THRESHOLD_ALERT,
+    BLOCKED,
+    UNBLOCKED,
+    POLICY_CHANGED,
+    MISSION_CREATED,
+    REWARD_REQUESTED,
+    REWARD_APPROVED,
+    REWARD_REJECTED,
+    APPEAL_CREATED,
+    APPEAL_APPROVED,
+    APPEAL_REJECTED,
+    EMERGENCY_APPROVED
+}

--- a/src/main/java/com/project/domain/notification/infra/messaging/NotificationKafkaConsumer.java
+++ b/src/main/java/com/project/domain/notification/infra/messaging/NotificationKafkaConsumer.java
@@ -66,6 +66,7 @@ public class NotificationKafkaConsumer {
                         envelope.payload().familyId());
                 notificationService.handleCustomerBlocked(envelope.payload(), envelope.timestamp());
             }
+            default -> log.warn("미지원 notification subType: {}", subType);
         }
     }
 }

--- a/src/main/java/com/project/domain/notification/infra/messaging/NotificationKafkaConsumer.java
+++ b/src/main/java/com/project/domain/notification/infra/messaging/NotificationKafkaConsumer.java
@@ -28,9 +28,9 @@ public class NotificationKafkaConsumer {
     private final NotificationService notificationService;
 
     @KafkaListener(topics = KafkaTopics.NOTIFICATION)
-    public void consume(ConsumerRecord<String, String> record) {
+    public void consume(ConsumerRecord<String, String> consumerRecord) {
         try {
-            JsonNode tree = kafkaEventMessageSupport.readTree(record.value());
+            JsonNode tree = kafkaEventMessageSupport.readTree(consumerRecord.value());
             String eventType = kafkaEventMessageSupport.extractEventType(tree);
 
             if (!KafkaEventTypes.NOTIFICATION.equals(eventType)) {

--- a/src/main/java/com/project/domain/notification/infra/messaging/NotificationKafkaConsumer.java
+++ b/src/main/java/com/project/domain/notification/infra/messaging/NotificationKafkaConsumer.java
@@ -1,0 +1,74 @@
+package com.project.domain.notification.infra.messaging;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import com.dabom.messaging.kafka.contract.KafkaEventTypes;
+import com.dabom.messaging.kafka.contract.KafkaTopics;
+import com.dabom.messaging.kafka.event.KafkaEventMessageSupport;
+import com.dabom.messaging.kafka.event.dto.EventEnvelope;
+import com.dabom.messaging.kafka.event.dto.notification.CustomerBlockedPayload;
+import com.dabom.messaging.kafka.event.dto.notification.NotificationSubTypes;
+import com.dabom.messaging.kafka.event.dto.notification.ThresholdAlertPayload;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.project.domain.notification.service.NotificationService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class NotificationKafkaConsumer {
+
+    private final KafkaEventMessageSupport kafkaEventMessageSupport;
+    private final NotificationService notificationService;
+
+    @KafkaListener(topics = KafkaTopics.NOTIFICATION)
+    public void consume(ConsumerRecord<String, String> record) {
+        try {
+            JsonNode tree = kafkaEventMessageSupport.readTree(record.value());
+            String eventType = kafkaEventMessageSupport.extractEventType(tree);
+
+            if (!KafkaEventTypes.NOTIFICATION.equals(eventType)) {
+                return;
+            }
+
+            String subType = tree.path("subType").asText();
+            dispatch(tree, subType);
+        } catch (JsonProcessingException e) {
+            log.error("Notification 이벤트 파싱 실패: {}", e.getMessage());
+        }
+    }
+
+    private void dispatch(JsonNode tree, String subType) {
+        switch (subType) {
+            case NotificationSubTypes.THRESHOLD_ALERT -> {
+                EventEnvelope<ThresholdAlertPayload> envelope =
+                        kafkaEventMessageSupport.convertToEnvelope(
+                                tree, new TypeReference<EventEnvelope<ThresholdAlertPayload>>() {});
+                log.info(
+                        "ThresholdAlert 수신 familyId={}, threshold={}%",
+                        envelope.payload().familyId(), envelope.payload().thresholdPercent());
+                notificationService.handleThresholdAlert(envelope.payload(), envelope.timestamp());
+            }
+            case NotificationSubTypes.CUSTOMER_BLOCKED -> {
+                EventEnvelope<CustomerBlockedPayload> envelope =
+                        kafkaEventMessageSupport.convertToEnvelope(
+                                tree,
+                                new TypeReference<EventEnvelope<CustomerBlockedPayload>>() {});
+                log.info(
+                        "CustomerBlocked 수신 customerId={}, familyId={}",
+                        envelope.payload().customerId(),
+                        envelope.payload().familyId());
+                notificationService.handleCustomerBlocked(envelope.payload(), envelope.timestamp());
+            }
+            case NotificationSubTypes.QUOTA_UPDATED ->
+                    log.debug("QuotaUpdated 이벤트 수신 — 알림 저장 대상 아님, 무시");
+            default -> log.warn("미지원 notification subType: {}", subType);
+        }
+    }
+}

--- a/src/main/java/com/project/domain/notification/infra/messaging/NotificationKafkaConsumer.java
+++ b/src/main/java/com/project/domain/notification/infra/messaging/NotificationKafkaConsumer.java
@@ -66,9 +66,6 @@ public class NotificationKafkaConsumer {
                         envelope.payload().familyId());
                 notificationService.handleCustomerBlocked(envelope.payload(), envelope.timestamp());
             }
-            case NotificationSubTypes.QUOTA_UPDATED ->
-                    log.debug("QuotaUpdated 이벤트 수신 — 알림 저장 대상 아님, 무시");
-            default -> log.warn("미지원 notification subType: {}", subType);
         }
     }
 }

--- a/src/main/java/com/project/domain/notification/repository/NotificationLogRepository.java
+++ b/src/main/java/com/project/domain/notification/repository/NotificationLogRepository.java
@@ -1,0 +1,7 @@
+package com.project.domain.notification.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.project.domain.notification.entity.NotificationLog;
+
+public interface NotificationLogRepository extends JpaRepository<NotificationLog, Long> {}

--- a/src/main/java/com/project/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/project/domain/notification/service/NotificationService.java
@@ -1,0 +1,13 @@
+package com.project.domain.notification.service;
+
+import java.time.LocalDateTime;
+
+import com.dabom.messaging.kafka.event.dto.notification.CustomerBlockedPayload;
+import com.dabom.messaging.kafka.event.dto.notification.ThresholdAlertPayload;
+
+public interface NotificationService {
+
+    void handleThresholdAlert(ThresholdAlertPayload payload, LocalDateTime sentAt);
+
+    void handleCustomerBlocked(CustomerBlockedPayload payload, LocalDateTime sentAt);
+}

--- a/src/main/java/com/project/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/project/domain/notification/service/NotificationServiceImpl.java
@@ -1,0 +1,99 @@
+package com.project.domain.notification.service;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.dabom.messaging.kafka.event.dto.notification.CustomerBlockedPayload;
+import com.dabom.messaging.kafka.event.dto.notification.ThresholdAlertPayload;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.domain.family.repository.FamilyMemberRepository;
+import com.project.domain.notification.entity.NotificationLog;
+import com.project.domain.notification.entity.NotificationType;
+import com.project.domain.notification.repository.NotificationLogRepository;
+import com.project.domain.webpush.service.WebPushService;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class NotificationServiceImpl implements NotificationService {
+
+    private final NotificationLogRepository notificationLogRepository;
+    private final FamilyMemberRepository familyMemberRepository;
+    private final WebPushService webPushService;
+    private final ObjectMapper objectMapper;
+
+    @Transactional
+    @Override
+    public void handleThresholdAlert(ThresholdAlertPayload payload, LocalDateTime sentAt) {
+        String payloadJson = serializePayload(payload);
+        Long familyId = payload.familyId();
+        String message = payload.message();
+
+        List<Long> customerIds = familyMemberRepository.findCustomerIdsByFamilyId(familyId);
+
+        List<NotificationLog> logs =
+                customerIds.stream()
+                        .map(
+                                customerId ->
+                                        NotificationLog.builder()
+                                                .customerId(customerId)
+                                                .familyId(familyId)
+                                                .type(NotificationType.THRESHOLD_ALERT)
+                                                .message(message)
+                                                .payload(payloadJson)
+                                                .sentAt(sentAt)
+                                                .build())
+                        .toList();
+
+        notificationLogRepository.saveAll(logs);
+
+        try {
+            webPushService.sendToFamily(familyId, message);
+        } catch (Exception e) {
+            log.warn("ThresholdAlert 푸시 전송 실패 familyId={}: {}", familyId, e.getMessage());
+        }
+    }
+
+    @Transactional
+    @Override
+    public void handleCustomerBlocked(CustomerBlockedPayload payload, LocalDateTime sentAt) {
+        String payloadJson = serializePayload(payload);
+        Long customerId = payload.customerId();
+        Long familyId = payload.familyId();
+        String message = "데이터 사용이 차단되었습니다. 사유: " + payload.blockReason();
+
+        NotificationLog notificationLog =
+                NotificationLog.builder()
+                        .customerId(customerId)
+                        .familyId(familyId)
+                        .type(NotificationType.BLOCKED)
+                        .message(message)
+                        .payload(payloadJson)
+                        .sentAt(sentAt)
+                        .build();
+
+        notificationLogRepository.save(notificationLog);
+
+        try {
+            webPushService.sendToUser(customerId, message);
+        } catch (Exception e) {
+            log.warn("CustomerBlocked 푸시 전송 실패 customerId={}: {}", customerId, e.getMessage());
+        }
+    }
+
+    private String serializePayload(Object payload) {
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException e) {
+            log.error("Payload 직렬화 실패: {}", e.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/project/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/project/domain/notification/service/NotificationServiceImpl.java
@@ -59,7 +59,7 @@ public class NotificationServiceImpl implements NotificationService {
         try {
             webPushService.sendToFamily(familyId, message);
         } catch (Exception e) {
-            log.warn("ThresholdAlert 푸시 전송 실패 familyId={}: {}", familyId, e.getMessage());
+            log.warn("ThresholdAlert 푸시 전송 실패 familyId={}", familyId, e);
         }
     }
 
@@ -86,7 +86,7 @@ public class NotificationServiceImpl implements NotificationService {
         try {
             webPushService.sendToUser(customerId, message);
         } catch (Exception e) {
-            log.warn("CustomerBlocked 푸시 전송 실패 customerId={}: {}", customerId, e.getMessage());
+            log.warn("CustomerBlocked 푸시 전송 실패 customerId={}", customerId, e);
         }
     }
 
@@ -94,7 +94,7 @@ public class NotificationServiceImpl implements NotificationService {
         try {
             return objectMapper.writeValueAsString(payload);
         } catch (JsonProcessingException e) {
-            log.error("Payload 직렬화 실패: {}", e.getMessage());
+            log.error("Payload 직렬화 실패", e);
             return null;
         }
     }

--- a/src/main/java/com/project/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/project/domain/notification/service/NotificationServiceImpl.java
@@ -24,6 +24,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class NotificationServiceImpl implements NotificationService {
 
+    private static final String BLOCKED_MESSAGE_FORMAT = "데이터 사용이 차단되었습니다. 사유: %s";
+
     private final NotificationLogRepository notificationLogRepository;
     private final FamilyMemberRepository familyMemberRepository;
     private final WebPushService webPushService;
@@ -67,7 +69,7 @@ public class NotificationServiceImpl implements NotificationService {
         String payloadJson = serializePayload(payload);
         Long customerId = payload.customerId();
         Long familyId = payload.familyId();
-        String message = "데이터 사용이 차단되었습니다. 사유: " + payload.blockReason();
+        String message = String.format(BLOCKED_MESSAGE_FORMAT, payload.blockReason());
 
         NotificationLog notificationLog =
                 NotificationLog.builder()

--- a/src/main/java/com/project/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/project/domain/notification/service/NotificationServiceImpl.java
@@ -15,6 +15,8 @@ import com.project.domain.notification.entity.NotificationLog;
 import com.project.domain.notification.entity.NotificationType;
 import com.project.domain.notification.repository.NotificationLogRepository;
 import com.project.domain.webpush.service.WebPushService;
+import com.project.global.exception.ApplicationException;
+import com.project.global.exception.code.NotificationErrorCode;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -95,7 +97,7 @@ public class NotificationServiceImpl implements NotificationService {
             return objectMapper.writeValueAsString(payload);
         } catch (JsonProcessingException e) {
             log.error("Payload 직렬화 실패", e);
-            return null;
+            throw new ApplicationException(NotificationErrorCode.NOTIFICATION_SAVE_FAILED);
         }
     }
 }

--- a/src/main/java/com/project/global/exception/code/NotificationErrorCode.java
+++ b/src/main/java/com/project/global/exception/code/NotificationErrorCode.java
@@ -1,0 +1,17 @@
+package com.project.global.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum NotificationErrorCode implements BaseErrorCode {
+    NOTIFICATION_SAVE_FAILED(
+            HttpStatus.INTERNAL_SERVER_ERROR, "NOTIFICATION_001", "알림 저장에 실패했습니다.");
+
+    private final HttpStatus httpStatus;
+    private final String customCode;
+    private final String message;
+}

--- a/src/test/java/com/project/domain/notification/service/NotificationServiceImplTest.java
+++ b/src/test/java/com/project/domain/notification/service/NotificationServiceImplTest.java
@@ -66,8 +66,13 @@ class NotificationServiceImplTest {
 
             verify(notificationLogRepository).saveAll(logsCaptor.capture());
             List<NotificationLog> saved = logsCaptor.getValue();
-            assertThat(saved).hasSize(2);
             assertThat(saved)
+                    .hasSize(2)
+                    .satisfies(
+                            logs -> {
+                                assertThat(logs.get(0).getCustomerId()).isEqualTo(CUSTOMER_ID_1);
+                                assertThat(logs.get(1).getCustomerId()).isEqualTo(CUSTOMER_ID_2);
+                            })
                     .allSatisfy(
                             log -> {
                                 assertThat(log.getFamilyId()).isEqualTo(FAMILY_ID);
@@ -77,8 +82,6 @@ class NotificationServiceImplTest {
                                 assertThat(log.getSentAt()).isEqualTo(SENT_AT);
                                 assertThat(log.isRead()).isFalse();
                             });
-            assertThat(saved.get(0).getCustomerId()).isEqualTo(CUSTOMER_ID_1);
-            assertThat(saved.get(1).getCustomerId()).isEqualTo(CUSTOMER_ID_2);
             verify(webPushService).sendToFamily(FAMILY_ID, "데이터 50% 사용");
         }
 

--- a/src/test/java/com/project/domain/notification/service/NotificationServiceImplTest.java
+++ b/src/test/java/com/project/domain/notification/service/NotificationServiceImplTest.java
@@ -25,6 +25,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.dabom.messaging.kafka.event.dto.notification.CustomerBlockedPayload;
 import com.dabom.messaging.kafka.event.dto.notification.ThresholdAlertPayload;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.domain.family.repository.FamilyMemberRepository;
 import com.project.domain.notification.entity.NotificationLog;
@@ -50,6 +51,11 @@ class NotificationServiceImplTest {
     private static final Long CUSTOMER_ID_1 = 10L;
     private static final Long CUSTOMER_ID_2 = 11L;
     private static final LocalDateTime SENT_AT = LocalDateTime.of(2026, 3, 14, 12, 0, 0);
+    private static final String THRESHOLD_PAYLOAD_JSON =
+            "{\"familyId\":1,\"thresholdPercent\":50,\"message\":\"데이터 50% 사용\"}";
+    private static final String BLOCKED_PAYLOAD_JSON =
+            "{\"familyId\":1,\"customerId\":10,\"blockReason\":\"MONTHLY_LIMIT_EXCEEDED\","
+                    + "\"blockedAt\":\"2026-03-14T12:00\"}";
 
     @Nested
     @DisplayName("handleThresholdAlert")
@@ -57,10 +63,11 @@ class NotificationServiceImplTest {
 
         @Test
         @DisplayName("가족 구성원 수만큼 NotificationLog 생성 후 sendToFamily 호출")
-        void createsLogsForAllFamilyMembers() {
+        void createsLogsForAllFamilyMembers() throws JsonProcessingException {
             ThresholdAlertPayload payload = new ThresholdAlertPayload(FAMILY_ID, 50, "데이터 50% 사용");
             when(familyMemberRepository.findCustomerIdsByFamilyId(FAMILY_ID))
                     .thenReturn(List.of(CUSTOMER_ID_1, CUSTOMER_ID_2));
+            when(objectMapper.writeValueAsString(payload)).thenReturn(THRESHOLD_PAYLOAD_JSON);
 
             notificationService.handleThresholdAlert(payload, SENT_AT);
 
@@ -79,6 +86,7 @@ class NotificationServiceImplTest {
                                 assertThat(log.getType())
                                         .isEqualTo(NotificationType.THRESHOLD_ALERT);
                                 assertThat(log.getMessage()).isEqualTo("데이터 50% 사용");
+                                assertThat(log.getPayload()).isEqualTo(THRESHOLD_PAYLOAD_JSON);
                                 assertThat(log.getSentAt()).isEqualTo(SENT_AT);
                                 assertThat(log.isRead()).isFalse();
                             });
@@ -121,10 +129,11 @@ class NotificationServiceImplTest {
 
         @Test
         @DisplayName("차단된 고객에게 NotificationLog 1건 생성 후 sendToUser 호출")
-        void createsLogAndSendsPush() {
+        void createsLogAndSendsPush() throws JsonProcessingException {
             CustomerBlockedPayload payload =
                     new CustomerBlockedPayload(
                             FAMILY_ID, CUSTOMER_ID_1, "MONTHLY_LIMIT_EXCEEDED", "2026-03-14T12:00");
+            when(objectMapper.writeValueAsString(payload)).thenReturn(BLOCKED_PAYLOAD_JSON);
 
             notificationService.handleCustomerBlocked(payload, SENT_AT);
 
@@ -134,6 +143,7 @@ class NotificationServiceImplTest {
             assertThat(saved.getFamilyId()).isEqualTo(FAMILY_ID);
             assertThat(saved.getType()).isEqualTo(NotificationType.BLOCKED);
             assertThat(saved.getMessage()).contains("MONTHLY_LIMIT_EXCEEDED");
+            assertThat(saved.getPayload()).isEqualTo(BLOCKED_PAYLOAD_JSON);
             assertThat(saved.getSentAt()).isEqualTo(SENT_AT);
             assertThat(saved.isRead()).isFalse();
             verify(webPushService).sendToUser(eq(CUSTOMER_ID_1), anyString());

--- a/src/test/java/com/project/domain/notification/service/NotificationServiceImplTest.java
+++ b/src/test/java/com/project/domain/notification/service/NotificationServiceImplTest.java
@@ -2,6 +2,7 @@ package com.project.domain.notification.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -32,6 +33,7 @@ import com.project.domain.notification.entity.NotificationLog;
 import com.project.domain.notification.entity.NotificationType;
 import com.project.domain.notification.repository.NotificationLogRepository;
 import com.project.domain.webpush.service.WebPushService;
+import com.project.global.exception.ApplicationException;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("NotificationServiceImpl 단위 테스트")
@@ -163,6 +165,22 @@ class NotificationServiceImplTest {
                     .doesNotThrowAnyException();
 
             verify(notificationLogRepository).save(any(NotificationLog.class));
+        }
+    }
+
+    @Nested
+    @DisplayName("serializePayload 실패")
+    class SerializePayloadFailure {
+
+        @Test
+        @DisplayName("직렬화 실패 시 ApplicationException 발생")
+        void throwsApplicationException() throws JsonProcessingException {
+            ThresholdAlertPayload payload = new ThresholdAlertPayload(FAMILY_ID, 50, "데이터 50% 사용");
+            when(objectMapper.writeValueAsString(payload))
+                    .thenThrow(new JsonProcessingException("serialize error") {});
+
+            assertThatThrownBy(() -> notificationService.handleThresholdAlert(payload, SENT_AT))
+                    .isInstanceOf(ApplicationException.class);
         }
     }
 }

--- a/src/test/java/com/project/domain/notification/service/NotificationServiceImplTest.java
+++ b/src/test/java/com/project/domain/notification/service/NotificationServiceImplTest.java
@@ -1,0 +1,155 @@
+package com.project.domain.notification.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.dabom.messaging.kafka.event.dto.notification.CustomerBlockedPayload;
+import com.dabom.messaging.kafka.event.dto.notification.ThresholdAlertPayload;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.project.domain.family.repository.FamilyMemberRepository;
+import com.project.domain.notification.entity.NotificationLog;
+import com.project.domain.notification.entity.NotificationType;
+import com.project.domain.notification.repository.NotificationLogRepository;
+import com.project.domain.webpush.service.WebPushService;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("NotificationServiceImpl 단위 테스트")
+class NotificationServiceImplTest {
+
+    @Mock private NotificationLogRepository notificationLogRepository;
+    @Mock private FamilyMemberRepository familyMemberRepository;
+    @Mock private WebPushService webPushService;
+    @Mock private ObjectMapper objectMapper;
+
+    @InjectMocks private NotificationServiceImpl notificationService;
+
+    @Captor private ArgumentCaptor<List<NotificationLog>> logsCaptor;
+    @Captor private ArgumentCaptor<NotificationLog> logCaptor;
+
+    private static final Long FAMILY_ID = 1L;
+    private static final Long CUSTOMER_ID_1 = 10L;
+    private static final Long CUSTOMER_ID_2 = 11L;
+    private static final LocalDateTime SENT_AT = LocalDateTime.of(2026, 3, 14, 12, 0, 0);
+
+    @Nested
+    @DisplayName("handleThresholdAlert")
+    class HandleThresholdAlert {
+
+        @Test
+        @DisplayName("가족 구성원 수만큼 NotificationLog 생성 후 sendToFamily 호출")
+        void createsLogsForAllFamilyMembers() {
+            ThresholdAlertPayload payload = new ThresholdAlertPayload(FAMILY_ID, 50, "데이터 50% 사용");
+            when(familyMemberRepository.findCustomerIdsByFamilyId(FAMILY_ID))
+                    .thenReturn(List.of(CUSTOMER_ID_1, CUSTOMER_ID_2));
+
+            notificationService.handleThresholdAlert(payload, SENT_AT);
+
+            verify(notificationLogRepository).saveAll(logsCaptor.capture());
+            List<NotificationLog> saved = logsCaptor.getValue();
+            assertThat(saved).hasSize(2);
+            assertThat(saved)
+                    .allSatisfy(
+                            log -> {
+                                assertThat(log.getFamilyId()).isEqualTo(FAMILY_ID);
+                                assertThat(log.getType())
+                                        .isEqualTo(NotificationType.THRESHOLD_ALERT);
+                                assertThat(log.getMessage()).isEqualTo("데이터 50% 사용");
+                                assertThat(log.getSentAt()).isEqualTo(SENT_AT);
+                                assertThat(log.isRead()).isFalse();
+                            });
+            assertThat(saved.get(0).getCustomerId()).isEqualTo(CUSTOMER_ID_1);
+            assertThat(saved.get(1).getCustomerId()).isEqualTo(CUSTOMER_ID_2);
+            verify(webPushService).sendToFamily(FAMILY_ID, "데이터 50% 사용");
+        }
+
+        @Test
+        @DisplayName("가족 구성원이 없으면 빈 리스트 저장, 푸시는 호출")
+        void emptyFamilyMembers_savesEmptyList() {
+            ThresholdAlertPayload payload = new ThresholdAlertPayload(FAMILY_ID, 50, "데이터 50% 사용");
+            when(familyMemberRepository.findCustomerIdsByFamilyId(FAMILY_ID)).thenReturn(List.of());
+
+            notificationService.handleThresholdAlert(payload, SENT_AT);
+
+            verify(notificationLogRepository).saveAll(logsCaptor.capture());
+            assertThat(logsCaptor.getValue()).isEmpty();
+            verify(webPushService).sendToFamily(FAMILY_ID, "데이터 50% 사용");
+        }
+
+        @Test
+        @DisplayName("푸시 전송 실패 시 예외 전파 없이 정상 완료")
+        void pushFailure_doesNotPropagate() {
+            ThresholdAlertPayload payload = new ThresholdAlertPayload(FAMILY_ID, 50, "데이터 50% 사용");
+            when(familyMemberRepository.findCustomerIdsByFamilyId(FAMILY_ID))
+                    .thenReturn(List.of(CUSTOMER_ID_1));
+            doThrow(new RuntimeException("push failed"))
+                    .when(webPushService)
+                    .sendToFamily(anyLong(), anyString());
+
+            assertThatCode(() -> notificationService.handleThresholdAlert(payload, SENT_AT))
+                    .doesNotThrowAnyException();
+
+            verify(notificationLogRepository).saveAll(any());
+        }
+    }
+
+    @Nested
+    @DisplayName("handleCustomerBlocked")
+    class HandleCustomerBlocked {
+
+        @Test
+        @DisplayName("차단된 고객에게 NotificationLog 1건 생성 후 sendToUser 호출")
+        void createsLogAndSendsPush() {
+            CustomerBlockedPayload payload =
+                    new CustomerBlockedPayload(
+                            FAMILY_ID, CUSTOMER_ID_1, "MONTHLY_LIMIT_EXCEEDED", "2026-03-14T12:00");
+
+            notificationService.handleCustomerBlocked(payload, SENT_AT);
+
+            verify(notificationLogRepository).save(logCaptor.capture());
+            NotificationLog saved = logCaptor.getValue();
+            assertThat(saved.getCustomerId()).isEqualTo(CUSTOMER_ID_1);
+            assertThat(saved.getFamilyId()).isEqualTo(FAMILY_ID);
+            assertThat(saved.getType()).isEqualTo(NotificationType.BLOCKED);
+            assertThat(saved.getMessage()).contains("MONTHLY_LIMIT_EXCEEDED");
+            assertThat(saved.getSentAt()).isEqualTo(SENT_AT);
+            assertThat(saved.isRead()).isFalse();
+            verify(webPushService).sendToUser(eq(CUSTOMER_ID_1), anyString());
+        }
+
+        @Test
+        @DisplayName("푸시 전송 실패 시 예외 전파 없이 정상 완료")
+        void pushFailure_doesNotPropagate() {
+            CustomerBlockedPayload payload =
+                    new CustomerBlockedPayload(
+                            FAMILY_ID, CUSTOMER_ID_1, "MONTHLY_LIMIT_EXCEEDED", "2026-03-14T12:00");
+            doThrow(new RuntimeException("subscription not found"))
+                    .when(webPushService)
+                    .sendToUser(anyLong(), anyString());
+
+            assertThatCode(() -> notificationService.handleCustomerBlocked(payload, SENT_AT))
+                    .doesNotThrowAnyException();
+
+            verify(notificationLogRepository).save(any(NotificationLog.class));
+        }
+    }
+}


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

- closed: #18
- jira: DABOM-397

---

## 🎯 목적

PWA Push 서버가 구현되어 있지만 `notification-events` Kafka 토픽을 소비하는 Consumer가 없어서, Kafka 이벤트 → 자동 푸시 전송 경로가 존재하지 않는 문제를 해결합니다.

`notification-events` 토픽을 소비하여 `notification_log` 테이블에 알림 이력을 저장하고, 동시에 PWA 푸시 알림을 전송하는 전체 파이프라인을 구현합니다.

## 📝 변경 사항

- `NotificationType` ENUM 생성 (ERD 3.9 기반 12개 알림 타입)
- `NotificationLog` Entity 생성 (`notification_log` 테이블 매핑)
- `NotificationLogRepository` 생성
- `NotificationService` Interface + Impl 구현
  - `handleThresholdAlert`: 가족 전체 구성원에게 알림 저장 + `sendToFamily` 푸시
  - `handleCustomerBlocked`: 차단된 고객에게 알림 저장 + `sendToUser` 푸시
  - 푸시 전송 실패 시 예외 비전파 (best-effort)
- `NotificationKafkaConsumer` 구현 (subType별 파싱/라우팅 → Service 위임)
- `NotificationErrorCode` 도메인 에러 코드 추가
- `NotificationServiceImplTest` 단위 테스트 5건 작성

## 📂 변경 범위

| 도메인 | controller | service | repository | entity | infra | global |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
| notification |     | [x] | [x] | [x] | [x] | [x] |

---

## 🖥️ 주요 코드 설명

**Kafka 소비 흐름** (`NotificationKafkaConsumer`):
```java
// notification-events 토픽 수신 → subType별 분기
@KafkaListener(topics = KafkaTopics.NOTIFICATION)
public void consume(ConsumerRecord<String, String> record) {
    JsonNode tree = kafkaEventMessageSupport.readTree(record.value());
    String subType = tree.path("subType").asText();
    // THRESHOLD_ALERT → notificationService.handleThresholdAlert()
    // CUSTOMER_BLOCKED → notificationService.handleCustomerBlocked()
    // QUOTA_UPDATED → 무시 (알림 저장 대상 아님)
}
```

**알림 처리** (`NotificationServiceImpl`):
- `THRESHOLD_ALERT`: `familyId`로 가족 전체 구성원 조회 → 각각 `notification_log` 저장 → `sendToFamily()` 푸시
- `CUSTOMER_BLOCKED`: 차단된 `customerId`에 대해 `notification_log` 1건 저장 → `sendToUser()` 푸시
- 푸시 전송은 best-effort: 실패해도 DB 저장은 보장, 예외는 경고 로그만 기록

## 💬 리뷰어에게

- `QUOTA_UPDATED` 이벤트는 사용자 대면 알림이 아닌 것으로 판단하여 `notification_log`에 저장하지 않습니다.
- Consumer는 표준 consumer group(`dabom-api-notification`)을 사용합니다. (broadcast 아님 → 로드밸런싱)

---

## 📋 체크리스트

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [x] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

- 향후 `UNBLOCKED`, `POLICY_CHANGED`, `MISSION_CREATED` 등 추가 subType은 lib-kafka에 Payload가 추가되면 같은 패턴으로 확장 가능
