### PR TITLE
[DABOM-474] 알림 API 개선

### DIFF
--- a/src/main/java/com/project/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/project/domain/notification/controller/NotificationController.java
@@ -10,11 +10,11 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-import com.dabom.messaging.kafka.event.dto.notification.NotificationType;
 import com.project.domain.notification.dto.NotificationSlice;
 import com.project.domain.notification.dto.response.NotificationListResponse;
 import com.project.domain.notification.dto.response.NotificationResponse;
 import com.project.domain.notification.dto.response.UnreadCountResponse;
+import com.project.domain.notification.entity.NotificationType;
 import com.project.domain.notification.service.NotificationService;
 import com.project.global.api.response.ApiResponse;
 import com.project.global.auth.aop.CustomerId;

--- a/src/main/java/com/project/domain/notification/entity/NotificationLog.java
+++ b/src/main/java/com/project/domain/notification/entity/NotificationLog.java
@@ -11,7 +11,6 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 
-import com.dabom.messaging.kafka.event.dto.notification.NotificationType;
 import com.project.global.util.BaseEntity;
 
 import lombok.AccessLevel;

--- a/src/main/java/com/project/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/project/domain/notification/entity/NotificationType.java
@@ -1,5 +1,8 @@
 package com.project.domain.notification.entity;
 
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
 public enum NotificationType {
     QUOTA_UPDATED,
     THRESHOLD_ALERT,
@@ -15,4 +18,14 @@ public enum NotificationType {
     APPEAL_REJECTED,
     EMERGENCY_APPROVED,
     ADMIN_PUSH;
+
+    public static NotificationType from(
+            com.dabom.messaging.kafka.event.dto.notification.NotificationType libType) {
+        try {
+            return valueOf(libType.name());
+        } catch (IllegalArgumentException e) {
+            log.warn("지원하지 않는 Kafka 알림 타입: {}", libType.name());
+            throw new IllegalArgumentException("지원하지 않는 알림 타입: " + libType.name(), e);
+        }
+    }
 }

--- a/src/main/java/com/project/domain/notification/entity/NotificationType.java
+++ b/src/main/java/com/project/domain/notification/entity/NotificationType.java
@@ -1,0 +1,18 @@
+package com.project.domain.notification.entity;
+
+public enum NotificationType {
+    QUOTA_UPDATED,
+    THRESHOLD_ALERT,
+    CUSTOMER_BLOCKED,
+    CUSTOMER_UNBLOCKED,
+    POLICY_CHANGED,
+    MISSION_CREATED,
+    REWARD_REQUESTED,
+    REWARD_APPROVED,
+    REWARD_REJECTED,
+    APPEAL_CREATED,
+    APPEAL_APPROVED,
+    APPEAL_REJECTED,
+    EMERGENCY_APPROVED,
+    ADMIN_PUSH;
+}

--- a/src/main/java/com/project/domain/notification/repository/NotificationLogRepositoryCustom.java
+++ b/src/main/java/com/project/domain/notification/repository/NotificationLogRepositoryCustom.java
@@ -3,8 +3,8 @@ package com.project.domain.notification.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.dabom.messaging.kafka.event.dto.notification.NotificationType;
 import com.project.domain.notification.entity.NotificationLog;
+import com.project.domain.notification.entity.NotificationType;
 
 public interface NotificationLogRepositoryCustom {
 

--- a/src/main/java/com/project/domain/notification/repository/NotificationLogRepositoryImpl.java
+++ b/src/main/java/com/project/domain/notification/repository/NotificationLogRepositoryImpl.java
@@ -3,8 +3,8 @@ package com.project.domain.notification.repository;
 import java.time.LocalDateTime;
 import java.util.List;
 
-import com.dabom.messaging.kafka.event.dto.notification.NotificationType;
 import com.project.domain.notification.entity.NotificationLog;
+import com.project.domain.notification.entity.NotificationType;
 import com.project.domain.notification.entity.QNotificationLog;
 import com.querydsl.core.BooleanBuilder;
 import com.querydsl.jpa.impl.JPAQueryFactory;

--- a/src/main/java/com/project/domain/notification/service/NotificationEventServiceImpl.java
+++ b/src/main/java/com/project/domain/notification/service/NotificationEventServiceImpl.java
@@ -11,6 +11,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.domain.family.repository.FamilyMemberRepository;
 import com.project.domain.notification.entity.NotificationLog;
+import com.project.domain.notification.entity.NotificationType;
 import com.project.domain.notification.repository.NotificationLogRepository;
 import com.project.domain.usagerecord.infra.sse.SsePublisher;
 import com.project.domain.webpush.service.WebPushService;
@@ -66,7 +67,7 @@ public class NotificationEventServiceImpl implements NotificationEventService {
                 NotificationLog.builder()
                         .customerId(customerId)
                         .familyId(payload.familyId())
-                        .type(payload.type())
+                        .type(NotificationType.valueOf(payload.type().name()))
                         .title(payload.title())
                         .message(payload.message())
                         .payload(payloadJson)

--- a/src/main/java/com/project/domain/notification/service/NotificationEventServiceImpl.java
+++ b/src/main/java/com/project/domain/notification/service/NotificationEventServiceImpl.java
@@ -67,22 +67,12 @@ public class NotificationEventServiceImpl implements NotificationEventService {
                 NotificationLog.builder()
                         .customerId(customerId)
                         .familyId(payload.familyId())
-                        .type(toLocalNotificationType(payload.type()))
+                        .type(NotificationType.from(payload.type()))
                         .title(payload.title())
                         .message(payload.message())
                         .payload(payloadJson)
                         .sentAt(sentAt)
                         .build());
-    }
-
-    private NotificationType toLocalNotificationType(
-            com.dabom.messaging.kafka.event.dto.notification.NotificationType libType) {
-        try {
-            return NotificationType.valueOf(libType.name());
-        } catch (IllegalArgumentException e) {
-            log.warn("지원하지 않는 Kafka 알림 타입: {}", libType.name());
-            throw new ApplicationException(NotificationErrorCode.NOTIFICATION_SAVE_FAILED);
-        }
     }
 
     private String serializePayload(Object payload) {

--- a/src/main/java/com/project/domain/notification/service/NotificationEventServiceImpl.java
+++ b/src/main/java/com/project/domain/notification/service/NotificationEventServiceImpl.java
@@ -67,12 +67,22 @@ public class NotificationEventServiceImpl implements NotificationEventService {
                 NotificationLog.builder()
                         .customerId(customerId)
                         .familyId(payload.familyId())
-                        .type(NotificationType.valueOf(payload.type().name()))
+                        .type(toLocalNotificationType(payload.type()))
                         .title(payload.title())
                         .message(payload.message())
                         .payload(payloadJson)
                         .sentAt(sentAt)
                         .build());
+    }
+
+    private NotificationType toLocalNotificationType(
+            com.dabom.messaging.kafka.event.dto.notification.NotificationType libType) {
+        try {
+            return NotificationType.valueOf(libType.name());
+        } catch (IllegalArgumentException e) {
+            log.warn("지원하지 않는 Kafka 알림 타입: {}", libType.name());
+            throw new ApplicationException(NotificationErrorCode.NOTIFICATION_SAVE_FAILED);
+        }
     }
 
     private String serializePayload(Object payload) {

--- a/src/main/java/com/project/domain/notification/service/NotificationService.java
+++ b/src/main/java/com/project/domain/notification/service/NotificationService.java
@@ -2,8 +2,8 @@ package com.project.domain.notification.service;
 
 import java.util.List;
 
-import com.dabom.messaging.kafka.event.dto.notification.NotificationType;
 import com.project.domain.notification.dto.NotificationSlice;
+import com.project.domain.notification.entity.NotificationType;
 
 public interface NotificationService {
 
@@ -17,4 +17,6 @@ public interface NotificationService {
     void markAllAsRead(Long customerId);
 
     void deleteNotification(Long notificationId, Long customerId);
+
+    void saveAdminPushNotification(Long customerId, String title, String message);
 }

--- a/src/main/java/com/project/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/project/domain/notification/service/NotificationServiceImpl.java
@@ -7,9 +7,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.dabom.messaging.kafka.event.dto.notification.NotificationType;
+import com.project.domain.family.repository.FamilyMemberRepository;
 import com.project.domain.notification.dto.NotificationSlice;
 import com.project.domain.notification.entity.NotificationLog;
+import com.project.domain.notification.entity.NotificationType;
 import com.project.domain.notification.repository.NotificationLogRepository;
 import com.project.global.exception.ApplicationException;
 import com.project.global.exception.code.NotificationErrorCode;
@@ -24,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
 public class NotificationServiceImpl implements NotificationService {
 
     private final NotificationLogRepository notificationLogRepository;
+    private final FamilyMemberRepository familyMemberRepository;
     private final CursorUtil cursorUtil;
 
     @Value("${app.notification.retention-days}")
@@ -82,6 +84,28 @@ public class NotificationServiceImpl implements NotificationService {
     public void deleteNotification(Long notificationId, Long customerId) {
         NotificationLog notification = findOwnedNotification(notificationId, customerId);
         notification.softDelete();
+    }
+
+    @Transactional
+    @Override
+    public void saveAdminPushNotification(Long customerId, String title, String message) {
+        Long familyId =
+                familyMemberRepository
+                        .findFamilyIdByCustomerId(customerId)
+                        .orElseThrow(
+                                () ->
+                                        new ApplicationException(
+                                                NotificationErrorCode.NOTIFICATION_SAVE_FAILED));
+
+        notificationLogRepository.save(
+                NotificationLog.builder()
+                        .customerId(customerId)
+                        .familyId(familyId)
+                        .type(NotificationType.ADMIN_PUSH)
+                        .title(title)
+                        .message(message)
+                        .sentAt(LocalDateTime.now())
+                        .build());
     }
 
     private NotificationLog findOwnedNotification(Long notificationId, Long customerId) {

--- a/src/main/java/com/project/domain/notification/service/NotificationServiceImpl.java
+++ b/src/main/java/com/project/domain/notification/service/NotificationServiceImpl.java
@@ -95,7 +95,8 @@ public class NotificationServiceImpl implements NotificationService {
                         .orElseThrow(
                                 () ->
                                         new ApplicationException(
-                                                NotificationErrorCode.NOTIFICATION_SAVE_FAILED));
+                                                NotificationErrorCode
+                                                        .TARGET_CUSTOMER_NOT_IN_FAMILY));
 
         notificationLogRepository.save(
                 NotificationLog.builder()

--- a/src/main/java/com/project/domain/webpush/controller/WebPushController.java
+++ b/src/main/java/com/project/domain/webpush/controller/WebPushController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.project.domain.notification.service.NotificationService;
 import com.project.domain.webpush.dto.request.AdminPushRequest;
 import com.project.domain.webpush.dto.request.PushSubscriptionRequest;
 import com.project.domain.webpush.dto.response.VapidPublicKeyResponse;
@@ -29,6 +30,7 @@ import lombok.extern.slf4j.Slf4j;
 public class WebPushController {
 
     private final WebPushService webPushService;
+    private final NotificationService notificationService;
 
     @GetMapping("/vapid-public-key")
     public ApiResponse<VapidPublicKeyResponse> getVapidPublicKey() {
@@ -53,6 +55,8 @@ public class WebPushController {
     @PostMapping("/send")
     public ApiResponse<Void> sendPushMessage(@Valid @RequestBody AdminPushRequest request) {
         log.info("Push message send requested for customerId={}", request.customerId());
+        notificationService.saveAdminPushNotification(
+                request.customerId(), request.title(), request.message());
         webPushService.sendToUser(request.customerId(), request.title(), request.message());
         return ApiResponse.success(null);
     }

--- a/src/main/java/com/project/domain/webpush/service/WebPushServiceImpl.java
+++ b/src/main/java/com/project/domain/webpush/service/WebPushServiceImpl.java
@@ -16,6 +16,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.jose4j.lang.JoseException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -97,7 +98,7 @@ public class WebPushServiceImpl implements WebPushService {
         pushSubscriptionRepository.delete(subscription);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
     @Override
     public void sendToUser(Long customerId, String title, String message) {
         PushSubscription subscription =
@@ -111,7 +112,7 @@ public class WebPushServiceImpl implements WebPushService {
         sendPushNotification(subscription, title, message);
     }
 
-    @Transactional(readOnly = true)
+    @Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
     @Override
     public void sendToFamily(Long familyId, String title, String message) {
         List<Long> customerIds = familyMemberRepository.findCustomerIdsByFamilyId(familyId);

--- a/src/main/java/com/project/global/exception/code/NotificationErrorCode.java
+++ b/src/main/java/com/project/global/exception/code/NotificationErrorCode.java
@@ -11,7 +11,9 @@ public enum NotificationErrorCode implements BaseErrorCode {
     NOTIFICATION_SAVE_FAILED(
             HttpStatus.INTERNAL_SERVER_ERROR, "NOTIFICATION_001", "알림 저장에 실패했습니다."),
     NOTIFICATION_FORBIDDEN(HttpStatus.FORBIDDEN, "NOTIFICATION_002", "해당 알림에 대한 권한이 없습니다."),
-    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_003", "알림을 찾을 수 없습니다.");
+    NOTIFICATION_NOT_FOUND(HttpStatus.NOT_FOUND, "NOTIFICATION_003", "알림을 찾을 수 없습니다."),
+    TARGET_CUSTOMER_NOT_IN_FAMILY(
+            HttpStatus.BAD_REQUEST, "NOTIFICATION_004", "해당 고객의 가족 정보를 찾을 수 없습니다.");
 
     private final HttpStatus httpStatus;
     private final String customCode;

--- a/src/test/java/com/project/domain/notification/service/NotificationEventServiceImplTest.java
+++ b/src/test/java/com/project/domain/notification/service/NotificationEventServiceImplTest.java
@@ -26,11 +26,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import com.dabom.messaging.kafka.event.dto.notification.NotificationPayload;
-import com.dabom.messaging.kafka.event.dto.notification.NotificationType;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.project.domain.family.repository.FamilyMemberRepository;
 import com.project.domain.notification.entity.NotificationLog;
+import com.project.domain.notification.entity.NotificationType;
 import com.project.domain.notification.repository.NotificationLogRepository;
 import com.project.domain.usagerecord.infra.sse.SsePublisher;
 import com.project.domain.webpush.service.WebPushService;
@@ -66,7 +66,8 @@ class NotificationEventServiceImplTest {
                     new NotificationPayload(
                             FAMILY_ID,
                             null,
-                            NotificationType.THRESHOLD_ALERT,
+                            com.dabom.messaging.kafka.event.dto.notification.NotificationType
+                                    .THRESHOLD_ALERT,
                             "데이터 경고",
                             "데이터 50% 사용",
                             Map.of("thresholdPercent", 50));
@@ -100,7 +101,8 @@ class NotificationEventServiceImplTest {
                     new NotificationPayload(
                             FAMILY_ID,
                             null,
-                            NotificationType.THRESHOLD_ALERT,
+                            com.dabom.messaging.kafka.event.dto.notification.NotificationType
+                                    .THRESHOLD_ALERT,
                             "데이터 경고",
                             "데이터 50% 사용",
                             Map.of());
@@ -128,7 +130,8 @@ class NotificationEventServiceImplTest {
                     new NotificationPayload(
                             FAMILY_ID,
                             CUSTOMER_ID_1,
-                            NotificationType.CUSTOMER_BLOCKED,
+                            com.dabom.messaging.kafka.event.dto.notification.NotificationType
+                                    .CUSTOMER_BLOCKED,
                             "데이터 차단",
                             "데이터 사용이 차단되었습니다.",
                             Map.of("blockReason", "MONTHLY_LIMIT_EXCEEDED"));
@@ -152,7 +155,8 @@ class NotificationEventServiceImplTest {
                     new NotificationPayload(
                             FAMILY_ID,
                             CUSTOMER_ID_1,
-                            NotificationType.CUSTOMER_BLOCKED,
+                            com.dabom.messaging.kafka.event.dto.notification.NotificationType
+                                    .CUSTOMER_BLOCKED,
                             "데이터 차단",
                             "차단됨",
                             Map.of());
@@ -178,7 +182,8 @@ class NotificationEventServiceImplTest {
                     new NotificationPayload(
                             FAMILY_ID,
                             null,
-                            NotificationType.THRESHOLD_ALERT,
+                            com.dabom.messaging.kafka.event.dto.notification.NotificationType
+                                    .THRESHOLD_ALERT,
                             "데이터 경고",
                             "msg",
                             Map.of());

--- a/src/test/java/com/project/domain/notification/service/NotificationServiceImplTest.java
+++ b/src/test/java/com/project/domain/notification/service/NotificationServiceImplTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -20,9 +21,10 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import com.dabom.messaging.kafka.event.dto.notification.NotificationType;
+import com.project.domain.family.repository.FamilyMemberRepository;
 import com.project.domain.notification.dto.NotificationSlice;
 import com.project.domain.notification.entity.NotificationLog;
+import com.project.domain.notification.entity.NotificationType;
 import com.project.domain.notification.repository.NotificationLogRepository;
 import com.project.global.exception.ApplicationException;
 import com.project.global.util.CursorUtil;
@@ -32,6 +34,7 @@ import com.project.global.util.CursorUtil;
 class NotificationServiceImplTest {
 
     @Mock private NotificationLogRepository notificationLogRepository;
+    @Mock private FamilyMemberRepository familyMemberRepository;
     @Mock private CursorUtil cursorUtil;
 
     @InjectMocks private NotificationServiceImpl notificationService;
@@ -205,6 +208,45 @@ class NotificationServiceImplTest {
                                     notificationService.deleteNotification(
                                             NOTIFICATION_ID, CUSTOMER_ID))
                     .isInstanceOf(ApplicationException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("saveAdminPushNotification")
+    class SaveAdminPushNotification {
+
+        @Test
+        @DisplayName("관리자 푸시 알림을 ADMIN_PUSH 타입으로 저장")
+        void savesNotificationWithAdminPushType() {
+            when(familyMemberRepository.findFamilyIdByCustomerId(CUSTOMER_ID))
+                    .thenReturn(Optional.of(FAMILY_ID));
+
+            notificationService.saveAdminPushNotification(CUSTOMER_ID, "공지", "서버 점검 안내");
+
+            org.mockito.ArgumentCaptor<NotificationLog> captor =
+                    org.mockito.ArgumentCaptor.forClass(NotificationLog.class);
+            verify(notificationLogRepository).save(captor.capture());
+            NotificationLog saved = captor.getValue();
+            assertThat(saved.getCustomerId()).isEqualTo(CUSTOMER_ID);
+            assertThat(saved.getFamilyId()).isEqualTo(FAMILY_ID);
+            assertThat(saved.getType()).isEqualTo(NotificationType.ADMIN_PUSH);
+            assertThat(saved.getTitle()).isEqualTo("공지");
+            assertThat(saved.getMessage()).isEqualTo("서버 점검 안내");
+        }
+
+        @Test
+        @DisplayName("가족 정보 없으면 예외 발생")
+        void throwsWhenFamilyNotFound() {
+            when(familyMemberRepository.findFamilyIdByCustomerId(CUSTOMER_ID))
+                    .thenReturn(Optional.empty());
+
+            assertThatThrownBy(
+                            () ->
+                                    notificationService.saveAdminPushNotification(
+                                            CUSTOMER_ID, "공지", "메시지"))
+                    .isInstanceOf(ApplicationException.class);
+
+            verify(notificationLogRepository, never()).save(any());
         }
     }
 }

--- a/src/test/java/com/project/domain/notification/service/NotificationServiceImplTest.java
+++ b/src/test/java/com/project/domain/notification/service/NotificationServiceImplTest.java
@@ -27,6 +27,7 @@ import com.project.domain.notification.entity.NotificationLog;
 import com.project.domain.notification.entity.NotificationType;
 import com.project.domain.notification.repository.NotificationLogRepository;
 import com.project.global.exception.ApplicationException;
+import com.project.global.exception.code.NotificationErrorCode;
 import com.project.global.util.CursorUtil;
 
 @ExtendWith(MockitoExtension.class)
@@ -244,7 +245,13 @@ class NotificationServiceImplTest {
                             () ->
                                     notificationService.saveAdminPushNotification(
                                             CUSTOMER_ID, "공지", "메시지"))
-                    .isInstanceOf(ApplicationException.class);
+                    .isInstanceOf(ApplicationException.class)
+                    .satisfies(
+                            ex ->
+                                    assertThat(((ApplicationException) ex).getCode())
+                                            .isEqualTo(
+                                                    NotificationErrorCode
+                                                            .TARGET_CUSTOMER_NOT_IN_FAMILY));
 
             verify(notificationLogRepository, never()).save(any());
         }


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

- closed: #23
- jira: DABOM-474

---

## 🎯 목적

Kafka 이벤트를 통한 알림 저장 시 푸시 전송 실패가 전체 트랜잭션을 롤백시키는 버그를 수정하고, `notification_log` 도메인의 lib-kafka 직접 의존을 제거하여 비-Kafka 경로(관리자 푸시 등)에서도 알림 이력을 저장할 수 있도록 개선합니다.

## 📝 변경 사항

- **푸시 전송 실패 시 알림 저장 트랜잭션 롤백 방지**
  - `WebPushServiceImpl.sendToUser`/`sendToFamily`에 `Propagation.REQUIRES_NEW` 적용
  - 푸시 전송이 독립 트랜잭션에서 실행되어 실패해도 외부 트랜잭션(알림 저장)에 영향 없음
- **도메인 자체 `NotificationType` enum 생성 및 lib-kafka 의존 분리**
  - `notification.entity.NotificationType` enum 신규 생성 (기존 13개 + `ADMIN_PUSH`)
  - `NotificationLog`, Repository, Service, Controller의 lib-kafka `NotificationType` 참조를 로컬 enum으로 전환
  - `NotificationEventServiceImpl`에서 lib-kafka → 로컬 enum 매핑 (`valueOf`)
- **`/push/send` 관리자 푸시 시 `notification_log` 저장**
  - `NotificationService.saveAdminPushNotification` 메서드 추가
  - `ADMIN_PUSH` 타입으로 `notification_log`에 알림 이력 저장
  - `WebPushController.sendPushMessage`에서 푸시 전송 전 알림 저장 호출
  - 단위 테스트 2건 추가

## 📂 변경 범위

| 도메인 | controller | service | repository | entity | infra | global |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
| notification |  | [x] |  | [x] |  |  |
| webpush | [x] | [x] |  |  |  |  |

---

## 🖥️ 주요 코드 설명

**트랜잭션 분리** (`WebPushServiceImpl`):
```java
// 기존: @Transactional(readOnly = true) → 외부 트랜잭션에 합류, 실패 시 rollback-only 전파
// 수정: Propagation.REQUIRES_NEW → 독립 트랜잭션, 실패해도 외부 트랜잭션 영향 없음
@Transactional(readOnly = true, propagation = Propagation.REQUIRES_NEW)
public void sendToUser(Long customerId, String title, String message) { ... }
```

**lib-kafka 의존 분리** (`NotificationEventServiceImpl`):
```java
// lib-kafka NotificationType → 로컬 NotificationType 매핑
.type(NotificationType.valueOf(payload.type().name()))
```

## 💬 리뷰어에게

- `Propagation.REQUIRES_NEW` 적용으로 best-effort 푸시 전략이 실제로 정상 동작합니다. 기존에는 `try-catch`로 예외를 잡아도 Spring 트랜잭션 프록시가 먼저 rollback-only를 마킹하여 `UnexpectedRollbackException`이 발생했습니다.
- `ADMIN_PUSH` 타입을 사용하려면 DB에 `ALTER TABLE notification_log MODIFY COLUMN type ENUM(... , 'ADMIN_PUSH') NOT NULL;` 실행이 필요합니다.
- 로컬 `NotificationType` enum의 값 이름은 lib-kafka enum과 동일하게 유지하여 `valueOf` 매핑이 안전합니다.

---

## 📋 체크리스트

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [x] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

- DB `notification_log.type` ENUM에 `ADMIN_PUSH` 값 추가 ALTER TABLE 필요 (배포 시 1회 실행)
- `@Transactional`이 Service뿐 아니라 `WebPushServiceImpl`에도 선언되어 있으나, 이는 `Propagation.REQUIRES_NEW`를 통한 트랜잭션 분리 목적으로 의도된 설계입니다
