### PR TITLE
[DABOM-499] 상태코드 개선 작업

### DIFF
--- a/src/main/java/com/project/common/api/response/ApiResponse.java
+++ b/src/main/java/com/project/common/api/response/ApiResponse.java
@@ -35,10 +35,6 @@ public class ApiResponse<T> {
         return new ApiResponse<>(true, data, null);
     }
 
-    public static <T> ApiResponse<T> created(T data) {
-        return new ApiResponse<>(true, data, null);
-    }
-
     public static ApiResponse<Void> fail(String code, String message, Object details) {
         return new ApiResponse<>(false, null, new ApiError(code, message, details));
     }

--- a/src/main/java/com/project/common/exception/ErrorResponse.java
+++ b/src/main/java/com/project/common/exception/ErrorResponse.java
@@ -1,3 +1,0 @@
-package com.project.common.exception;
-
-public record ErrorResponse(int status, String code, String message) {}

--- a/src/main/java/com/project/common/exception/ExceptionAdvice.java
+++ b/src/main/java/com/project/common/exception/ExceptionAdvice.java
@@ -2,12 +2,15 @@ package com.project.common.exception;
 
 import jakarta.servlet.http.HttpServletRequest;
 
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
+import com.project.common.api.response.ApiResponse;
 import com.project.common.exception.code.BaseErrorCode;
 import com.project.common.exception.code.GlobalErrorCode;
 
@@ -19,27 +22,41 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
     /** BaseException - 도메인 예외 (ex: ApplicationException) */
     @ExceptionHandler(BaseException.class)
-    public ResponseEntity<Object> handleBaseException(BaseException e, HttpServletRequest request) {
+    public ResponseEntity<ApiResponse<Void>> handleBaseException(
+            BaseException e, HttpServletRequest request) {
         BaseErrorCode code = e.getCode();
         log.error("[BaseException] {} - {}", code.name(), code.getMessage());
 
-        ErrorResponse response =
-                new ErrorResponse(
-                        code.getHttpStatus().value(), code.getCustomCode(), code.getMessage());
-
-        return ResponseEntity.status(code.getHttpStatus()).body(response);
+        return ResponseEntity.status(code.getHttpStatus())
+                .body(ApiResponse.fail(code.getCustomCode(), code.getMessage(), null));
     }
 
     /** 그 외 모든 예외 */
-    public ResponseEntity<Object> handleUnhandledException(Exception e, WebRequest request) {
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<ApiResponse<Void>> handleUnhandledException(
+            Exception e, WebRequest request) {
         log.error("[Exception] Unhandled: {}", e.getMessage(), e);
 
         GlobalErrorCode code = GlobalErrorCode.INTERNAL_SERVER_ERROR;
 
-        ErrorResponse response =
-                new ErrorResponse(
-                        code.getHttpStatus().value(), code.getCustomCode(), code.getMessage());
+        return ResponseEntity.status(code.getHttpStatus())
+                .body(ApiResponse.fail(code.getCustomCode(), code.getMessage(), null));
+    }
 
-        return ResponseEntity.status(code.getHttpStatus()).body(response);
+    /** Spring MVC 예외 (MethodArgumentNotValid, HttpRequestMethodNotSupported 등) */
+    @Override
+    protected ResponseEntity<Object> handleExceptionInternal(
+            Exception ex,
+            Object body,
+            HttpHeaders headers,
+            HttpStatusCode statusCode,
+            WebRequest request) {
+        log.error("[Spring MVC Exception] {}: {}", ex.getClass().getSimpleName(), ex.getMessage());
+
+        GlobalErrorCode code = GlobalErrorCode.INVALID_INPUT_VALUE;
+        ApiResponse<Void> response =
+                ApiResponse.fail(code.getCustomCode(), code.getMessage(), null);
+
+        return ResponseEntity.status(statusCode).headers(headers).body(response);
     }
 }

--- a/src/main/java/com/project/common/exception/ExceptionAdvice.java
+++ b/src/main/java/com/project/common/exception/ExceptionAdvice.java
@@ -5,6 +5,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.lang.Nullable;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
@@ -47,7 +48,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
     @Override
     protected ResponseEntity<Object> handleExceptionInternal(
             Exception ex,
-            Object body,
+            @Nullable Object body,
             HttpHeaders headers,
             HttpStatusCode statusCode,
             WebRequest request) {

--- a/src/main/java/com/project/common/exception/ExceptionAdvice.java
+++ b/src/main/java/com/project/common/exception/ExceptionAdvice.java
@@ -1,7 +1,5 @@
 package com.project.common.exception;
 
-import jakarta.servlet.http.HttpServletRequest;
-
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
@@ -23,8 +21,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
     /** BaseException - 도메인 예외 (ex: ApplicationException) */
     @ExceptionHandler(BaseException.class)
-    public ResponseEntity<ApiResponse<Void>> handleBaseException(
-            BaseException e, HttpServletRequest request) {
+    public ResponseEntity<ApiResponse<Void>> handleBaseException(BaseException e) {
         BaseErrorCode code = e.getCode();
         log.error("[BaseException] {} - {}", code.name(), code.getMessage());
 
@@ -34,8 +31,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
     /** 그 외 모든 예외 */
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ApiResponse<Void>> handleUnhandledException(
-            Exception e, WebRequest request) {
+    public ResponseEntity<ApiResponse<Void>> handleUnhandledException(Exception e) {
         log.error("[Exception] Unhandled: {}", e.getMessage(), e);
 
         GlobalErrorCode code = GlobalErrorCode.INTERNAL_SERVER_ERROR;
@@ -56,7 +52,7 @@ public class ExceptionAdvice extends ResponseEntityExceptionHandler {
 
         GlobalErrorCode code = GlobalErrorCode.INVALID_INPUT_VALUE;
         ApiResponse<Void> response =
-                ApiResponse.fail(code.getCustomCode(), code.getMessage(), null);
+                ApiResponse.fail(code.getCustomCode(), code.getMessage(), ex.getMessage());
 
         return ResponseEntity.status(statusCode).headers(headers).body(response);
     }

--- a/src/main/java/com/project/domain/event/controller/EventStreamController.java
+++ b/src/main/java/com/project/domain/event/controller/EventStreamController.java
@@ -12,7 +12,6 @@ import com.project.domain.usagerecord.infra.sse.SseSubscriber;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,20 +24,18 @@ public class EventStreamController {
 
     @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     @Operation(summary = "실시간 이벤트 스트림 (SSE)")
-    @ApiResponses(
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "SSE 스트림 연결 성공"))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "SSE 스트림 연결 성공")
     public SseEmitter getEventStream(@Parameter(hidden = true) @CustomerId Long customerId) {
         return sseSubscriber.subscribe(customerId);
     }
 
     @GetMapping(value = "/stream/test/{customerId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     @Operation(summary = "실시간 이벤트 스트림 테스트")
-    @ApiResponses(
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "SSE 테스트 스트림 연결 성공"))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "SSE 테스트 스트림 연결 성공")
     public SseEmitter getEventStreamTest(@PathVariable Long customerId) {
         return sseSubscriber.subscribe(customerId);
     }

--- a/src/main/java/com/project/domain/event/controller/EventStreamController.java
+++ b/src/main/java/com/project/domain/event/controller/EventStreamController.java
@@ -25,14 +25,20 @@ public class EventStreamController {
 
     @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     @Operation(summary = "실시간 이벤트 스트림 (SSE)")
-    @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "SSE 스트림 연결 성공"))
+    @ApiResponses(
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "SSE 스트림 연결 성공"))
     public SseEmitter getEventStream(@Parameter(hidden = true) @CustomerId Long customerId) {
         return sseSubscriber.subscribe(customerId);
     }
 
     @GetMapping(value = "/stream/test/{customerId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     @Operation(summary = "실시간 이벤트 스트림 테스트")
-    @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "SSE 테스트 스트림 연결 성공"))
+    @ApiResponses(
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "SSE 테스트 스트림 연결 성공"))
     public SseEmitter getEventStreamTest(@PathVariable Long customerId) {
         return sseSubscriber.subscribe(customerId);
     }

--- a/src/main/java/com/project/domain/event/controller/EventStreamController.java
+++ b/src/main/java/com/project/domain/event/controller/EventStreamController.java
@@ -12,6 +12,7 @@ import com.project.domain.usagerecord.infra.sse.SseSubscriber;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 import lombok.RequiredArgsConstructor;
 
@@ -24,12 +25,14 @@ public class EventStreamController {
 
     @GetMapping(value = "/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     @Operation(summary = "실시간 이벤트 스트림 (SSE)")
+    @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "SSE 스트림 연결 성공"))
     public SseEmitter getEventStream(@Parameter(hidden = true) @CustomerId Long customerId) {
         return sseSubscriber.subscribe(customerId);
     }
 
     @GetMapping(value = "/stream/test/{customerId}", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
     @Operation(summary = "실시간 이벤트 스트림 테스트")
+    @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "SSE 테스트 스트림 연결 성공"))
     public SseEmitter getEventStreamTest(@PathVariable Long customerId) {
         return sseSubscriber.subscribe(customerId);
     }

--- a/src/main/java/com/project/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/project/domain/notification/controller/NotificationController.java
@@ -21,7 +21,6 @@ import com.project.domain.notification.service.NotificationService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 import lombok.RequiredArgsConstructor;
 
@@ -33,10 +32,9 @@ public class NotificationController {
     private final NotificationService notificationService;
 
     @Operation(summary = "알림 목록 조회", description = "커서 기반 페이지네이션으로 알림 목록을 조회한다.")
-    @ApiResponses(
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "조회 성공"))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "조회 성공")
     @GetMapping
     public ApiResponse<NotificationListResponse> getNotifications(
             @Parameter(hidden = true) @CustomerId Long customerId,
@@ -54,10 +52,9 @@ public class NotificationController {
     }
 
     @Operation(summary = "읽지 않은 알림 수 조회")
-    @ApiResponses(
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "조회 성공"))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "조회 성공")
     @GetMapping("/unread-count")
     public ApiResponse<UnreadCountResponse> getUnreadCount(
             @Parameter(hidden = true) @CustomerId Long customerId) {
@@ -66,10 +63,9 @@ public class NotificationController {
     }
 
     @Operation(summary = "알림 읽음 처리")
-    @ApiResponses(
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "읽음 처리 성공"))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "읽음 처리 성공")
     @PatchMapping("/{notificationId}/read")
     public ApiResponse<Void> markAsRead(
             @Parameter(hidden = true) @CustomerId Long customerId,
@@ -79,10 +75,9 @@ public class NotificationController {
     }
 
     @Operation(summary = "알림 전체 읽음 처리")
-    @ApiResponses(
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "전체 읽음 처리 성공"))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "전체 읽음 처리 성공")
     @PatchMapping("/read-all")
     public ApiResponse<Void> markAllAsRead(@Parameter(hidden = true) @CustomerId Long customerId) {
         notificationService.markAllAsRead(customerId);
@@ -90,10 +85,9 @@ public class NotificationController {
     }
 
     @Operation(summary = "알림 삭제")
-    @ApiResponses(
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "삭제 성공"))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "삭제 성공")
     @DeleteMapping("/{notificationId}")
     public ApiResponse<Void> deleteNotification(
             @Parameter(hidden = true) @CustomerId Long customerId,

--- a/src/main/java/com/project/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/project/domain/notification/controller/NotificationController.java
@@ -19,7 +19,9 @@ import com.project.domain.notification.dto.response.UnreadCountResponse;
 import com.project.domain.notification.entity.NotificationType;
 import com.project.domain.notification.service.NotificationService;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 import lombok.RequiredArgsConstructor;
 
@@ -30,6 +32,8 @@ public class NotificationController {
 
     private final NotificationService notificationService;
 
+    @Operation(summary = "알림 목록 조회", description = "커서 기반 페이지네이션으로 알림 목록을 조회한다.")
+    @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"))
     @GetMapping
     public ApiResponse<NotificationListResponse> getNotifications(
             @Parameter(hidden = true) @CustomerId Long customerId,
@@ -46,6 +50,8 @@ public class NotificationController {
                         responses, slice.nextCursor(), slice.hasNext(), slice.unreadCount()));
     }
 
+    @Operation(summary = "읽지 않은 알림 수 조회")
+    @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"))
     @GetMapping("/unread-count")
     public ApiResponse<UnreadCountResponse> getUnreadCount(
             @Parameter(hidden = true) @CustomerId Long customerId) {
@@ -53,6 +59,8 @@ public class NotificationController {
         return ApiResponse.success(new UnreadCountResponse(count));
     }
 
+    @Operation(summary = "알림 읽음 처리")
+    @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "읽음 처리 성공"))
     @PatchMapping("/{notificationId}/read")
     public ApiResponse<Void> markAsRead(
             @Parameter(hidden = true) @CustomerId Long customerId,
@@ -61,12 +69,16 @@ public class NotificationController {
         return ApiResponse.success(null);
     }
 
+    @Operation(summary = "알림 전체 읽음 처리")
+    @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "전체 읽음 처리 성공"))
     @PatchMapping("/read-all")
     public ApiResponse<Void> markAllAsRead(@Parameter(hidden = true) @CustomerId Long customerId) {
         notificationService.markAllAsRead(customerId);
         return ApiResponse.success(null);
     }
 
+    @Operation(summary = "알림 삭제")
+    @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "삭제 성공"))
     @DeleteMapping("/{notificationId}")
     public ApiResponse<Void> deleteNotification(
             @Parameter(hidden = true) @CustomerId Long customerId,

--- a/src/main/java/com/project/domain/notification/controller/NotificationController.java
+++ b/src/main/java/com/project/domain/notification/controller/NotificationController.java
@@ -33,7 +33,10 @@ public class NotificationController {
     private final NotificationService notificationService;
 
     @Operation(summary = "알림 목록 조회", description = "커서 기반 페이지네이션으로 알림 목록을 조회한다.")
-    @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"))
+    @ApiResponses(
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공"))
     @GetMapping
     public ApiResponse<NotificationListResponse> getNotifications(
             @Parameter(hidden = true) @CustomerId Long customerId,
@@ -51,7 +54,10 @@ public class NotificationController {
     }
 
     @Operation(summary = "읽지 않은 알림 수 조회")
-    @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"))
+    @ApiResponses(
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공"))
     @GetMapping("/unread-count")
     public ApiResponse<UnreadCountResponse> getUnreadCount(
             @Parameter(hidden = true) @CustomerId Long customerId) {
@@ -60,7 +66,10 @@ public class NotificationController {
     }
 
     @Operation(summary = "알림 읽음 처리")
-    @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "읽음 처리 성공"))
+    @ApiResponses(
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "읽음 처리 성공"))
     @PatchMapping("/{notificationId}/read")
     public ApiResponse<Void> markAsRead(
             @Parameter(hidden = true) @CustomerId Long customerId,
@@ -70,7 +79,10 @@ public class NotificationController {
     }
 
     @Operation(summary = "알림 전체 읽음 처리")
-    @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "전체 읽음 처리 성공"))
+    @ApiResponses(
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "전체 읽음 처리 성공"))
     @PatchMapping("/read-all")
     public ApiResponse<Void> markAllAsRead(@Parameter(hidden = true) @CustomerId Long customerId) {
         notificationService.markAllAsRead(customerId);
@@ -78,7 +90,10 @@ public class NotificationController {
     }
 
     @Operation(summary = "알림 삭제")
-    @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "삭제 성공"))
+    @ApiResponses(
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "삭제 성공"))
     @DeleteMapping("/{notificationId}")
     public ApiResponse<Void> deleteNotification(
             @Parameter(hidden = true) @CustomerId Long customerId,

--- a/src/main/java/com/project/domain/webpush/controller/WebPushController.java
+++ b/src/main/java/com/project/domain/webpush/controller/WebPushController.java
@@ -20,7 +20,6 @@ import com.project.domain.webpush.service.WebPushService;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
-import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -35,20 +34,18 @@ public class WebPushController {
     private final NotificationService notificationService;
 
     @Operation(summary = "VAPID 공개 키 조회")
-    @ApiResponses(
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "조회 성공"))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "조회 성공")
     @GetMapping("/vapid-public-key")
     public ApiResponse<VapidPublicKeyResponse> getVapidPublicKey() {
         return ApiResponse.success(new VapidPublicKeyResponse(webPushService.getVapidPublicKey()));
     }
 
     @Operation(summary = "푸시 알림 구독", description = "신규 구독 또는 기존 구독 갱신(업서트)을 처리한다.")
-    @ApiResponses(
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "구독 성공"))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "구독 성공")
     @PostMapping("/subscribe")
     public ApiResponse<Void> subscribe(
             @Parameter(hidden = true) @CustomerId Long customerId,
@@ -58,10 +55,9 @@ public class WebPushController {
     }
 
     @Operation(summary = "푸시 알림 구독 해제")
-    @ApiResponses(
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "구독 해제 성공"))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "구독 해제 성공")
     @DeleteMapping("/subscribe")
     public ApiResponse<Void> unsubscribe(@Parameter(hidden = true) @CustomerId Long customerId) {
         webPushService.unsubscribe(customerId);
@@ -69,10 +65,9 @@ public class WebPushController {
     }
 
     @Operation(summary = "관리자 푸시 알림 발송")
-    @ApiResponses(
-            @io.swagger.v3.oas.annotations.responses.ApiResponse(
-                    responseCode = "200",
-                    description = "발송 성공"))
+    @io.swagger.v3.oas.annotations.responses.ApiResponse(
+            responseCode = "200",
+            description = "발송 성공")
     @AdminOnly
     @PostMapping("/send")
     public ApiResponse<Void> sendPushMessage(@Valid @RequestBody AdminPushRequest request) {

--- a/src/main/java/com/project/domain/webpush/controller/WebPushController.java
+++ b/src/main/java/com/project/domain/webpush/controller/WebPushController.java
@@ -42,7 +42,7 @@ public class WebPushController {
             @Parameter(hidden = true) @CustomerId Long customerId,
             @Valid @RequestBody PushSubscriptionRequest subscriptionRequest) {
         webPushService.subscribe(subscriptionRequest, customerId);
-        return ApiResponse.created(null);
+        return ApiResponse.success(null);
     }
 
     @DeleteMapping("/subscribe")

--- a/src/main/java/com/project/domain/webpush/controller/WebPushController.java
+++ b/src/main/java/com/project/domain/webpush/controller/WebPushController.java
@@ -18,7 +18,9 @@ import com.project.domain.webpush.dto.request.PushSubscriptionRequest;
 import com.project.domain.webpush.dto.response.VapidPublicKeyResponse;
 import com.project.domain.webpush.service.WebPushService;
 
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -32,11 +34,15 @@ public class WebPushController {
     private final WebPushService webPushService;
     private final NotificationService notificationService;
 
+    @Operation(summary = "VAPID 공개 키 조회")
+    @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"))
     @GetMapping("/vapid-public-key")
     public ApiResponse<VapidPublicKeyResponse> getVapidPublicKey() {
         return ApiResponse.success(new VapidPublicKeyResponse(webPushService.getVapidPublicKey()));
     }
 
+    @Operation(summary = "푸시 알림 구독", description = "신규 구독 또는 기존 구독 갱신(업서트)을 처리한다.")
+    @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "구독 성공"))
     @PostMapping("/subscribe")
     public ApiResponse<Void> subscribe(
             @Parameter(hidden = true) @CustomerId Long customerId,
@@ -45,12 +51,16 @@ public class WebPushController {
         return ApiResponse.success(null);
     }
 
+    @Operation(summary = "푸시 알림 구독 해제")
+    @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "구독 해제 성공"))
     @DeleteMapping("/subscribe")
     public ApiResponse<Void> unsubscribe(@Parameter(hidden = true) @CustomerId Long customerId) {
         webPushService.unsubscribe(customerId);
         return ApiResponse.success(null);
     }
 
+    @Operation(summary = "관리자 푸시 알림 발송")
+    @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "발송 성공"))
     @AdminOnly
     @PostMapping("/send")
     public ApiResponse<Void> sendPushMessage(@Valid @RequestBody AdminPushRequest request) {

--- a/src/main/java/com/project/domain/webpush/controller/WebPushController.java
+++ b/src/main/java/com/project/domain/webpush/controller/WebPushController.java
@@ -35,14 +35,20 @@ public class WebPushController {
     private final NotificationService notificationService;
 
     @Operation(summary = "VAPID 공개 키 조회")
-    @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "조회 성공"))
+    @ApiResponses(
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "조회 성공"))
     @GetMapping("/vapid-public-key")
     public ApiResponse<VapidPublicKeyResponse> getVapidPublicKey() {
         return ApiResponse.success(new VapidPublicKeyResponse(webPushService.getVapidPublicKey()));
     }
 
     @Operation(summary = "푸시 알림 구독", description = "신규 구독 또는 기존 구독 갱신(업서트)을 처리한다.")
-    @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "구독 성공"))
+    @ApiResponses(
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "구독 성공"))
     @PostMapping("/subscribe")
     public ApiResponse<Void> subscribe(
             @Parameter(hidden = true) @CustomerId Long customerId,
@@ -52,7 +58,10 @@ public class WebPushController {
     }
 
     @Operation(summary = "푸시 알림 구독 해제")
-    @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "구독 해제 성공"))
+    @ApiResponses(
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "구독 해제 성공"))
     @DeleteMapping("/subscribe")
     public ApiResponse<Void> unsubscribe(@Parameter(hidden = true) @CustomerId Long customerId) {
         webPushService.unsubscribe(customerId);
@@ -60,7 +69,10 @@ public class WebPushController {
     }
 
     @Operation(summary = "관리자 푸시 알림 발송")
-    @ApiResponses(@io.swagger.v3.oas.annotations.responses.ApiResponse(responseCode = "200", description = "발송 성공"))
+    @ApiResponses(
+            @io.swagger.v3.oas.annotations.responses.ApiResponse(
+                    responseCode = "200",
+                    description = "발송 성공"))
     @AdminOnly
     @PostMapping("/send")
     public ApiResponse<Void> sendPushMessage(@Valid @RequestBody AdminPushRequest request) {

--- a/src/test/java/com/project/common/exception/ExceptionAdviceTest.java
+++ b/src/test/java/com/project/common/exception/ExceptionAdviceTest.java
@@ -1,0 +1,65 @@
+package com.project.common.exception;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.project.common.exception.code.NotificationErrorCode;
+
+class ExceptionAdviceTest {
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc =
+                MockMvcBuilders.standaloneSetup(new StubController())
+                        .setControllerAdvice(new ExceptionAdvice())
+                        .build();
+    }
+
+    @Test
+    @DisplayName("도메인 예외 발생 시 ApiResponse.fail() 형식으로 응답한다")
+    void domainException_returnsApiResponseFail() throws Exception {
+        mockMvc.perform(get("/test/domain-exception"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("NOTIFICATION_003"))
+                .andExpect(jsonPath("$.error.message").value("알림을 찾을 수 없습니다."))
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
+
+    @Test
+    @DisplayName("미처리 예외 발생 시 ApiResponse.fail() 형식으로 500 응답한다")
+    void unhandledException_returnsApiResponseFail() throws Exception {
+        mockMvc.perform(get("/test/unhandled-exception"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("GLOBAL_001"))
+                .andExpect(jsonPath("$.error.message").value("서버 내부 오류가 발생했습니다"))
+                .andExpect(jsonPath("$.timestamp").exists());
+    }
+
+    /** 테스트용 스텁 컨트롤러 */
+    @RestController
+    static class StubController {
+
+        @GetMapping("/test/domain-exception")
+        public void domainException() {
+            throw new ApplicationException(NotificationErrorCode.NOTIFICATION_NOT_FOUND);
+        }
+
+        @GetMapping("/test/unhandled-exception")
+        public void unhandledException() {
+            throw new RuntimeException("unexpected error");
+        }
+    }
+}

--- a/src/test/java/com/project/common/exception/ExceptionAdviceTest.java
+++ b/src/test/java/com/project/common/exception/ExceptionAdviceTest.java
@@ -83,7 +83,9 @@ class ExceptionAdviceTest {
         }
 
         @PostMapping("/test/validation")
-        public void validation(@Valid @RequestBody StubRequest request) {}
+        public void validation(@Valid @RequestBody StubRequest request) {
+            // 유효성 검증 실패를 유도하기 위한 빈 구현 (요청 바인딩만 수행)
+        }
     }
 
     record StubRequest(@NotBlank String name) {}

--- a/src/test/java/com/project/common/exception/ExceptionAdviceTest.java
+++ b/src/test/java/com/project/common/exception/ExceptionAdviceTest.java
@@ -1,15 +1,22 @@
 package com.project.common.exception;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.project.common.exception.code.NotificationErrorCode;
@@ -48,6 +55,19 @@ class ExceptionAdviceTest {
                 .andExpect(jsonPath("$.timestamp").exists());
     }
 
+    @Test
+    @DisplayName("Spring MVC 예외 발생 시 details에 원본 메시지를 포함한다")
+    void springMvcException_includesDetailsMessage() throws Exception {
+        mockMvc.perform(
+                        post("/test/validation")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content("{}"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.error.code").value("GLOBAL_002"))
+                .andExpect(jsonPath("$.error.details").exists());
+    }
+
     /** 테스트용 스텁 컨트롤러 */
     @RestController
     static class StubController {
@@ -61,5 +81,10 @@ class ExceptionAdviceTest {
         public void unhandledException() {
             throw new RuntimeException("unexpected error");
         }
+
+        @PostMapping("/test/validation")
+        public void validation(@Valid @RequestBody StubRequest request) {}
     }
+
+    record StubRequest(@NotBlank String name) {}
 }

--- a/src/test/java/com/project/common/support/StubCustomerIdResolver.java
+++ b/src/test/java/com/project/common/support/StubCustomerIdResolver.java
@@ -1,0 +1,29 @@
+package com.project.common.support;
+
+import org.springframework.core.MethodParameter;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.project.common.auth.aop.CustomerId;
+
+/** 테스트에서 @CustomerId 파라미터를 고정값으로 주입하는 스텁 리졸버 */
+public class StubCustomerIdResolver implements HandlerMethodArgumentResolver {
+
+    public static final Long CUSTOMER_ID = 1L;
+
+    @Override
+    public boolean supportsParameter(MethodParameter parameter) {
+        return parameter.hasParameterAnnotation(CustomerId.class);
+    }
+
+    @Override
+    public Object resolveArgument(
+            MethodParameter parameter,
+            ModelAndViewContainer mavContainer,
+            NativeWebRequest webRequest,
+            WebDataBinderFactory binderFactory) {
+        return CUSTOMER_ID;
+    }
+}

--- a/src/test/java/com/project/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/project/domain/notification/controller/NotificationControllerTest.java
@@ -1,9 +1,7 @@
 package com.project.domain.notification.controller;
 
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
@@ -38,11 +36,9 @@ class NotificationControllerTest {
 
     private static final Long CUSTOMER_ID = 1L;
 
-    @Mock
-    private NotificationService notificationService;
+    @Mock private NotificationService notificationService;
 
-    @InjectMocks
-    private NotificationController notificationController;
+    @InjectMocks private NotificationController notificationController;
 
     private MockMvc mockMvc;
 
@@ -104,7 +100,9 @@ class NotificationControllerTest {
                 .andExpect(jsonPath("$.data").doesNotExist());
     }
 
-    /** @CustomerId 파라미터를 고정값으로 주입하는 스텁 리졸버 */
+    /**
+     * @CustomerId 파라미터를 고정값으로 주입하는 스텁 리졸버
+     */
     static class StubCustomerIdResolver implements HandlerMethodArgumentResolver {
 
         @Override

--- a/src/test/java/com/project/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/project/domain/notification/controller/NotificationControllerTest.java
@@ -1,0 +1,124 @@
+package com.project.domain.notification.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.project.common.auth.aop.CustomerId;
+import com.project.domain.notification.dto.NotificationSlice;
+import com.project.domain.notification.service.NotificationService;
+
+@ExtendWith(MockitoExtension.class)
+class NotificationControllerTest {
+
+    private static final Long CUSTOMER_ID = 1L;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @InjectMocks
+    private NotificationController notificationController;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc =
+                MockMvcBuilders.standaloneSetup(notificationController)
+                        .setCustomArgumentResolvers(new StubCustomerIdResolver())
+                        .build();
+    }
+
+    @Test
+    @DisplayName("GET /notifications - 알림 목록 조회 시 200 OK를 반환한다")
+    void getNotifications_returns200() throws Exception {
+        when(notificationService.getNotifications(
+                        anyLong(), isNull(), anyInt(), isNull(), isNull()))
+                .thenReturn(new NotificationSlice(List.of(), null, false, 0L));
+
+        mockMvc.perform(get("/notifications"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true));
+    }
+
+    @Test
+    @DisplayName("GET /notifications/unread-count - 읽지 않은 알림 수 조회 시 200 OK를 반환한다")
+    void getUnreadCount_returns200() throws Exception {
+        when(notificationService.getUnreadCount(anyLong())).thenReturn(5L);
+
+        mockMvc.perform(get("/notifications/unread-count"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.unreadCount").value(5));
+    }
+
+    @Test
+    @DisplayName("PATCH /notifications/{id}/read - 알림 읽음 처리 시 200 OK를 반환한다")
+    void markAsRead_returns200() throws Exception {
+        mockMvc.perform(patch("/notifications/{notificationId}/read", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("PATCH /notifications/read-all - 전체 읽음 처리 시 200 OK를 반환한다")
+    void markAllAsRead_returns200() throws Exception {
+        mockMvc.perform(patch("/notifications/read-all"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("DELETE /notifications/{id} - 알림 삭제 시 200 OK를 반환한다")
+    void deleteNotification_returns200() throws Exception {
+        mockMvc.perform(delete("/notifications/{notificationId}", 1L))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    /** @CustomerId 파라미터를 고정값으로 주입하는 스텁 리졸버 */
+    static class StubCustomerIdResolver implements HandlerMethodArgumentResolver {
+
+        @Override
+        public boolean supportsParameter(MethodParameter parameter) {
+            return parameter.hasParameterAnnotation(CustomerId.class);
+        }
+
+        @Override
+        public Object resolveArgument(
+                MethodParameter parameter,
+                ModelAndViewContainer mavContainer,
+                NativeWebRequest webRequest,
+                WebDataBinderFactory binderFactory) {
+            return CUSTOMER_ID;
+        }
+    }
+}

--- a/src/test/java/com/project/domain/notification/controller/NotificationControllerTest.java
+++ b/src/test/java/com/project/domain/notification/controller/NotificationControllerTest.java
@@ -19,22 +19,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.core.MethodParameter;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.bind.support.WebDataBinderFactory;
-import org.springframework.web.context.request.NativeWebRequest;
-import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-import org.springframework.web.method.support.ModelAndViewContainer;
 
-import com.project.common.auth.aop.CustomerId;
+import com.project.common.support.StubCustomerIdResolver;
 import com.project.domain.notification.dto.NotificationSlice;
 import com.project.domain.notification.service.NotificationService;
 
 @ExtendWith(MockitoExtension.class)
 class NotificationControllerTest {
-
-    private static final Long CUSTOMER_ID = 1L;
 
     @Mock private NotificationService notificationService;
 
@@ -98,25 +91,5 @@ class NotificationControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").doesNotExist());
-    }
-
-    /**
-     * @CustomerId 파라미터를 고정값으로 주입하는 스텁 리졸버
-     */
-    static class StubCustomerIdResolver implements HandlerMethodArgumentResolver {
-
-        @Override
-        public boolean supportsParameter(MethodParameter parameter) {
-            return parameter.hasParameterAnnotation(CustomerId.class);
-        }
-
-        @Override
-        public Object resolveArgument(
-                MethodParameter parameter,
-                ModelAndViewContainer mavContainer,
-                NativeWebRequest webRequest,
-                WebDataBinderFactory binderFactory) {
-            return CUSTOMER_ID;
-        }
     }
 }

--- a/src/test/java/com/project/domain/webpush/controller/WebPushControllerTest.java
+++ b/src/test/java/com/project/domain/webpush/controller/WebPushControllerTest.java
@@ -1,6 +1,5 @@
 package com.project.domain.webpush.controller;
 
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -33,14 +32,11 @@ class WebPushControllerTest {
 
     private static final Long CUSTOMER_ID = 1L;
 
-    @Mock
-    private WebPushService webPushService;
+    @Mock private WebPushService webPushService;
 
-    @Mock
-    private NotificationService notificationService;
+    @Mock private NotificationService notificationService;
 
-    @InjectMocks
-    private WebPushController webPushController;
+    @InjectMocks private WebPushController webPushController;
 
     private MockMvc mockMvc;
 
@@ -116,7 +112,9 @@ class WebPushControllerTest {
                 .andExpect(jsonPath("$.data").doesNotExist());
     }
 
-    /** @CustomerId 파라미터를 고정값으로 주입하는 스텁 리졸버 */
+    /**
+     * @CustomerId 파라미터를 고정값으로 주입하는 스텁 리졸버
+     */
     static class StubCustomerIdResolver implements HandlerMethodArgumentResolver {
 
         @Override

--- a/src/test/java/com/project/domain/webpush/controller/WebPushControllerTest.java
+++ b/src/test/java/com/project/domain/webpush/controller/WebPushControllerTest.java
@@ -14,23 +14,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.core.MethodParameter;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.web.bind.support.WebDataBinderFactory;
-import org.springframework.web.context.request.NativeWebRequest;
-import org.springframework.web.method.support.HandlerMethodArgumentResolver;
-import org.springframework.web.method.support.ModelAndViewContainer;
 
-import com.project.common.auth.aop.CustomerId;
+import com.project.common.support.StubCustomerIdResolver;
 import com.project.domain.notification.service.NotificationService;
 import com.project.domain.webpush.service.WebPushService;
 
 @ExtendWith(MockitoExtension.class)
 class WebPushControllerTest {
-
-    private static final Long CUSTOMER_ID = 1L;
 
     @Mock private WebPushService webPushService;
 
@@ -110,25 +103,5 @@ class WebPushControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.success").value(true))
                 .andExpect(jsonPath("$.data").doesNotExist());
-    }
-
-    /**
-     * @CustomerId 파라미터를 고정값으로 주입하는 스텁 리졸버
-     */
-    static class StubCustomerIdResolver implements HandlerMethodArgumentResolver {
-
-        @Override
-        public boolean supportsParameter(MethodParameter parameter) {
-            return parameter.hasParameterAnnotation(CustomerId.class);
-        }
-
-        @Override
-        public Object resolveArgument(
-                MethodParameter parameter,
-                ModelAndViewContainer mavContainer,
-                NativeWebRequest webRequest,
-                WebDataBinderFactory binderFactory) {
-            return CUSTOMER_ID;
-        }
     }
 }

--- a/src/test/java/com/project/domain/webpush/controller/WebPushControllerTest.java
+++ b/src/test/java/com/project/domain/webpush/controller/WebPushControllerTest.java
@@ -1,0 +1,136 @@
+package com.project.domain.webpush.controller;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.core.MethodParameter;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.support.WebDataBinderFactory;
+import org.springframework.web.context.request.NativeWebRequest;
+import org.springframework.web.method.support.HandlerMethodArgumentResolver;
+import org.springframework.web.method.support.ModelAndViewContainer;
+
+import com.project.common.auth.aop.CustomerId;
+import com.project.domain.notification.service.NotificationService;
+import com.project.domain.webpush.service.WebPushService;
+
+@ExtendWith(MockitoExtension.class)
+class WebPushControllerTest {
+
+    private static final Long CUSTOMER_ID = 1L;
+
+    @Mock
+    private WebPushService webPushService;
+
+    @Mock
+    private NotificationService notificationService;
+
+    @InjectMocks
+    private WebPushController webPushController;
+
+    private MockMvc mockMvc;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc =
+                MockMvcBuilders.standaloneSetup(webPushController)
+                        .setCustomArgumentResolvers(new StubCustomerIdResolver())
+                        .build();
+    }
+
+    @Test
+    @DisplayName("GET /push/vapid-public-key - VAPID 공개 키 조회 시 200 OK를 반환한다")
+    void getVapidPublicKey_returns200() throws Exception {
+        when(webPushService.getVapidPublicKey()).thenReturn("test-vapid-key");
+
+        mockMvc.perform(get("/push/vapid-public-key"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data.publicKey").value("test-vapid-key"));
+    }
+
+    @Test
+    @DisplayName("POST /push/subscribe - 푸시 구독(업서트) 시 200 OK를 반환한다")
+    void subscribe_returns200() throws Exception {
+        String requestBody =
+                """
+                {
+                    "endpoint": "https://fcm.googleapis.com/fcm/send/test",
+                    "keys": {
+                        "p256dh": "test-p256dh-key",
+                        "auth": "test-auth-key"
+                    }
+                }
+                """;
+
+        mockMvc.perform(
+                        post("/push/subscribe")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("DELETE /push/subscribe - 푸시 구독 해제 시 200 OK를 반환한다")
+    void unsubscribe_returns200() throws Exception {
+        mockMvc.perform(delete("/push/subscribe"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("POST /push/send - 관리자 푸시 발송 시 200 OK를 반환한다")
+    void sendPushMessage_returns200() throws Exception {
+        String requestBody =
+                """
+                {
+                    "customerId": 1,
+                    "title": "테스트 제목",
+                    "message": "테스트 메시지"
+                }
+                """;
+
+        mockMvc.perform(
+                        post("/push/send")
+                                .contentType(MediaType.APPLICATION_JSON)
+                                .content(requestBody))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    /** @CustomerId 파라미터를 고정값으로 주입하는 스텁 리졸버 */
+    static class StubCustomerIdResolver implements HandlerMethodArgumentResolver {
+
+        @Override
+        public boolean supportsParameter(MethodParameter parameter) {
+            return parameter.hasParameterAnnotation(CustomerId.class);
+        }
+
+        @Override
+        public Object resolveArgument(
+                MethodParameter parameter,
+                ModelAndViewContainer mavContainer,
+                NativeWebRequest webRequest,
+                WebDataBinderFactory binderFactory) {
+            return CUSTOMER_ID;
+        }
+    }
+}


### PR DESCRIPTION
## 🍀 이슈 & 티켓 넘버

- closed: #28
- jira: DABOM-499

---

## 🎯 목적

API 응답 형식 일관성 확보 및 Swagger 문서화. 성공/에러 응답 모두 `ApiResponse<T>` 형식으로 통일하고, 컨트롤러에 OpenAPI 응답 코드를 명시하며, HTTP 상태 코드 계약을 테스트로 보장합니다.

## 📝 변경 사항

- **subscribe 응답 코드 계약 정리**: `POST /push/subscribe`가 업서트 API임에도 `ApiResponse.created()`를 사용하던 것을 `ApiResponse.success()`로 변경, 미사용 `ApiResponse.created()` 메서드 제거
- **ExceptionAdvice 에러 응답 통일**: `ErrorResponse` record 대신 `ApiResponse.fail()`을 사용하여 성공/에러 응답 형식 일관성 확보, `handleUnhandledException`에 누락된 `@ExceptionHandler` 추가, Spring MVC 예외도 `ApiResponse.fail()` 형식으로 변환하도록 `handleExceptionInternal` 오버라이드
- **Swagger 응답 코드 문서화**: 3개 컨트롤러 11개 엔드포인트에 `@Operation`, `@ApiResponses` 어노테이션 추가
- **컨트롤러 HTTP 상태 코드 검증 테스트**: NotificationController 5개, WebPushController 4개, ExceptionAdvice 2개 총 11개 MockMvc 테스트 추가

## 📂 변경 범위

| 도메인 | controller | service | repository | entity | infra | common |
| :----: | :--------: | :-----: | :--------: | :----: | :---: | :----: |
| notification | [x] | | | | | |
| webpush | [x] | | | | | |
| event | [x] | | | | | |
| common | | | | | | [x] |

---

## 🖥️ 주요 코드 설명

**에러 응답 형식 변경 (ExceptionAdvice)**

```java
// 변경 전: ErrorResponse 사용
ErrorResponse response = new ErrorResponse(
    code.getHttpStatus().value(), code.getCustomCode(), code.getMessage());
return ResponseEntity.status(code.getHttpStatus()).body(response);

// 변경 후: ApiResponse.fail() 사용
return ResponseEntity.status(code.getHttpStatus())
    .body(ApiResponse.fail(code.getCustomCode(), code.getMessage(), null));
```

응답 JSON 형식 변경:
```
변경 전: { "status": 404, "code": "NOTIFICATION_003", "message": "..." }
변경 후: { "success": false, "error": { "code": "...", "message": "..." }, "timestamp": "..." }
```

## 💬 리뷰어에게

- 에러 응답 형식이 변경되므로 **프론트엔드 에러 핸들링 코드 동기화**가 필요합니다. (`status` → `error.code`, `error.message` 경로 변경)
- `./gradlew build` 통과 확인 완료 (Spotless, Checkstyle 포함).

---

## 📋 체크리스트

**기본**
- [x] Merge 대상 브랜치가 올바른가?
- [x] `./gradlew build`가 정상적으로 통과하는가?
- [x] Spotless / Checkstyle을 통과하는가? (`./gradlew spotlessApply checkstyleMain`)
- [x] 전체 변경사항이 500줄을 넘지 않는가?

**코드 품질**
- [x] 의존성 방향을 준수하는가? (`Controller → Service → Repository → Entity`)
- [x] Setter 없이 비즈니스 메서드로 상태를 변경하는가?
- [x] `@Transactional`은 Service에만 선언했는가?

**테스트**
- [x] 신규 비즈니스 로직에 대한 단위 테스트를 작성했는가?

## 📌 참고 사항

- 에러 응답 형식 변경으로 인해 프론트엔드 측 `ErrorResponse` 파싱 로직 업데이트 필요
- `ApiResponse.created()` 메서드가 제거되었으므로, 향후 생성 API에서 201 반환이 필요하면 `@ResponseStatus(HttpStatus.CREATED)` 어노테이션 방식을 사용할 것
